### PR TITLE
Make using old PIP easier

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,5 @@
 graft src
+include CMakeLists.txt
+include LICENSE
+include pyproject.toml
+include README.md

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 
 Zivid Python is the official Python package for Zivid 3D cameras. Read more about Zivid at [zivid.com](https://www.zivid.com/).
 
-[![Build Status](https://img.shields.io/azure-devops/build/zivid-devops/376f5fda-ba80-4d6c-aaaa-cbcd5e0ad6c0/2/master.svg)](https://dev.azure.com/zivid-devops/zivid-python/_build/latest?definitionId=2&branchName=master)
+[![Build Status](https://img.shields.io/azure-devops/build/zivid-devops/376f5fda-ba80-4d6c-aaaa-cbcd5e0ad6c0/2/master.svg)](https://dev.azure.com/zivid-devops/zivid-python/_build/latest?definitionId=2&branchName=master) [![PyPI Package](https://img.shields.io/pypi/v/zivid.svg)](https://pypi.org/project/zivid/)
+
 
 <figure><p align="center"><img src="https://www.zivid.com/hs-fs/hubfs/images/www/ZividOnePlus.jpg?width=500&name=ZividOnePlus.jpg"></p></figure>
 
@@ -23,29 +24,24 @@ Zivid Python is the official Python package for Zivid 3D cameras. Read more abou
 
 *Windows users also needs to make sure that the Zivid SDK installation folder is in system `PATH` before using the package, not only the terminal PATH variable. The default install location that should be added to system `PATH` is `C:\Program Files\Zivid\bin`.*
 
-### Build and install the package
+### Using PIP
 
-The easiest way to install the package is to use PIP. This package requires [PIP version 19](https://pip.pypa.io/en/stable/installing/#upgrading-pip) or higher.
+The easiest way to install the package is to use PIP.
+
+On some systems Python 3 `pip` is called `pip3`. In this guide we assume it is called `pip`.
+
+When using PIP version 19 or higher build dependencies are handled automatically.
 
 Installation may take some time since the `setup.py` script will download additional dependencies and compile C++ source code in the background.
 
-#### Linux
+    pip install zivid
 
-    git clone https://github.com/zivid/zivid-python.git
-    cd zivid-python
-    python -m venv env
-    source env/bin/activate
-    pip install --upgrade pip
-    pip install .
+#### Old PIP
 
-#### Windows
+If you are using a version of PIP older than version 19 please manually install the dependencies listed in [pyproject.toml](pyproject.toml) before installing the zivid.
 
-    git clone https://github.com/zivid/zivid-python.git
-    cd zivid-python
-    python -m venv env
-    env\Scripts\activate.bat
-    python -m pip install --upgrade pip
-    pip install .
+    pip install scikit-build cmake ninja
+    pip install zivid
 
 ## Quick Start
 
@@ -75,7 +71,39 @@ Standalone example programs can be found in the [samples](samples) directory.
 
 ## Versioning
 
-This python module is using [PEP 440](https://www.python.org/dev/peps/pep-0440) for versioning. The features available in the module depends on the Zivid SDK version used  when building the module. When updating this Python package it is *reccomended* to also update to the latest [Zivid SDK](http://www.zivid.com/software). Refer to the [Test Matrix](#test-matrix) for supported version.
+This python module is using [PEP 440](https://www.python.org/dev/peps/pep-0440) for versioning. The features available in the module depends on the Zivid SDK version used when building the module. When updating this Python package it is *recommended* to also update to the latest [Zivid SDK](http://www.zivid.com/software). Refer to the [Test Matrix](#test-matrix) for supported version.
+
+The version number of the Zivid Python module consists of six numbers. The three first numbers of the version is the [semantic version](https://semver.org/) of the code in this repository. The last three numbers is the version of the underlying Zivid SDK library used by the Python module.
+
+### Version breakdown
+
+                                        Zivid SDK version = 1.4.1 (semantic version)
+                                        v v v
+    Zivid Python module version = 1.0.0.1.4.1
+                                  ^ ^ ^
+                                  Wrapper code version = 1.0.0 (semantic version)
+
+### PyPI
+
+When installing using pip it is possible to specify the required version. This can be useful if upgrading Zivid SDK is not desired, but you want to update Zivid Python.
+
+#### Install latest version of Zivid Python using latest version of Zivid SDK
+
+    pip install zivid
+
+#### Install version 1.0.0 of Zivid Python using latest version of Zivid SDK
+
+    pip install zivid==1.0.0
+
+#### Install version 1.0.0 of Zivid Python using Zivid SDK version 1.4.0
+
+    pip install zivid==1.0.0.1.4.0
+
+#### Install version 1.0.0 of Zivid Python using Zivid SDK version 1.3.0
+
+    pip install zivid==1.0.0.1.3.0
+    
+*Support for older versions of Zivid SDK will be discontinued when they are no longer compatible with latest version of the wrapper code.*
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,6 @@
 [build-system]
+# This list is duplicated in setup.py
+# Keep the two lists in sync
 requires = [
     "cmake",
     "ninja",

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
-from skbuild import setup
-
+from pkgutil import iter_modules
 
 # To be replaced by: from setuptools_scm import get_version
 def get_version():
-    return "0.9.0"
+    return "0.9.1"
 
 
 def _zivid_sdk_version():
@@ -29,22 +28,46 @@ def _zivid_python_version():
     return version
 
 
-setup(
-    name="zivid",
-    version=_zivid_python_version(),
-    description="Defining the Future of 3D Machine Vision",
-    long_description=open("README.md").read(),
-    long_description_content_type="text/markdown",
-    url="https://www.zivid.com",
-    author="Zivid AS",
-    author_email="support@zivid.com",
-    license=open("LICENSE").read(),
-    packages=["zivid", "_zivid"],
-    package_dir={"": "modules"},
-    install_requires=["numpy"],
-    cmake_args=[
-        "-DZIVID_PYTHON_VERSION=" + _zivid_python_version(),
-        "-DZIVID_SDK_VERSION=" + _zivid_sdk_version(),
-        "-Dpybind11_DIR=src/3rd-party/pybind11-2.2.4/share/cmake/pybind11/",
-    ],
-)
+def _check_dependency(module_name, package_hint=None):
+    if module_name not in [module[1] for module in iter_modules()]:
+        raise ImportError(
+            "Missing module '{}'. Please install '{}' manually or use PIP>=19 to handle build dependencies automatically (PEP 517).".format(
+                module_name, package_hint
+            )
+        )
+
+
+def _main():
+    # This list is a duplicate of the build-system requirments in pyproject.toml.
+    # The purpose of these checks is to help users with PIP<19 lacking support for
+    # pyproject.toml
+    # Keep the two lists in sync
+    _check_dependency("skbuild", "scikit-build")
+    _check_dependency("cmake")
+    _check_dependency("ninja")
+
+    from skbuild import setup
+
+    setup(
+        name="zivid",
+        version=_zivid_python_version(),
+        description="Defining the Future of 3D Machine Vision",
+        long_description=open("README.md").read(),
+        long_description_content_type="text/markdown",
+        url="https://www.zivid.com",
+        author="Zivid AS",
+        author_email="support@zivid.com",
+        license=open("LICENSE").read(),
+        packages=["zivid", "_zivid"],
+        package_dir={"": "modules"},
+        install_requires=["numpy"],
+        cmake_args=[
+            "-DZIVID_PYTHON_VERSION=" + _zivid_python_version(),
+            "-DZIVID_SDK_VERSION=" + _zivid_sdk_version(),
+            "-Dpybind11_DIR=src/3rd-party/pybind11-2.2.4/share/cmake/pybind11/",
+        ],
+    )
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
This change improves the diagnostics from setup.py. A new helpful
error messages will trigger if any dependencies are missing when
installing the package. This typically happens when PIP version is <19
and the user is missing the build dependencies.

Example error message:

    Missing module 'skbuild'. Please install 'scikit-build' manually
    or use PIP>=19 to handle build dependencies automatically (PEP
    517).

Version number is bumped to 0.9.1 and this version will be uploaded to
PyPI.

The README.md is now simplified to not use venv since we gracefully
handle older PIP version. It is also updated to install the package
from PyPI and not git.

The Versioning section of README.md is extended to explain what all
those digits in the module version is all about.