### PR TITLE
Raise a customized nested exception when _zivid fails at import

### DIFF
--- a/modules/_zivid/__init__.py
+++ b/modules/_zivid/__init__.py
@@ -1,15 +1,32 @@
 """This file imports used classes, modules and packages."""
-from _zivid._zivid import (  # pylint: disable=import-error,no-name-in-module
-    __version__,
-    Application,
-    Camera,
-    CameraState,
-    environment,
-    firmware,
-    Frame,
-    FrameInfo,
-    hdr,
-    PointCloud,
-    Settings,
-    version,
-)
+try:
+    from _zivid._zivid import (  # pylint: disable=import-error,no-name-in-module
+        __version__,
+        Application,
+        Camera,
+        CameraState,
+        environment,
+        firmware,
+        Frame,
+        FrameInfo,
+        hdr,
+        PointCloud,
+        Settings,
+        version,
+    )
+except ImportError as ex:
+    import platform
+
+    def __missing_sdk_error_message():
+        error_message = """Failed to import the Zivid Python C-module, please verify that:
+ - Zivid SDK is installed
+ - Zivid SDK version is matching the SDK version part of the Zivid Python version """
+        if platform.system() != "Windows":
+            return error_message
+        return (
+            error_message
+            + """
+ - Zivid SDK libraries location is in system PATH"""
+        )
+
+    raise ImportError(__missing_sdk_error_message()) from ex


### PR DESCRIPTION
The stacktrace from `import zivid` will now look like this:

```
Traceback (most recent call last):
  File "/tmp/env/lib/python3.7/site-packages/_zivid/__init__.py", line 3, in <module>
    from _zivid._zivid import (  # pylint: disable=import-error,no-name-in-module
ImportError: libZividCore.so: cannot open shared object file: No such file or directory

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/env/lib/python3.7/site-packages/zivid/__init__.py", line 8, in <module>
    from zivid.application import (
  File "/tmp/env/lib/python3.7/site-packages/zivid/application.py", line 2, in <module>
    import _zivid
  File "/tmp/env/lib/python3.7/site-packages/_zivid/__init__.py", line 23, in <module>
    ) from ex
ImportError: Failed to import the Zivid Python C-module, please check that:
 - Zivid SDK is installed
 - Zivid SDK version is matching the Zivid Python version
 - Zivid SDK libraries location is in PATH
```