### PR TITLE
Make Settings.__str__() output a valid YAML string

### DIFF
--- a/modules/zivid/settings.py
+++ b/modules/zivid/settings.py
@@ -33,9 +33,9 @@ class Settings:  # pylint: disable=too-many-instance-attributes, too-few-public-
                 return False
 
             def __str__(self):
-                return """Contrast:
-enabled: {}
-threshold: {}""".format(
+                return """
+        enabled: {}
+        threshold: {}""".format(
                     self.enabled, self.threshold
                 )
 
@@ -63,9 +63,9 @@ threshold: {}""".format(
                 return False
 
             def __str__(self):
-                return """Outlier:
-enabled: {}
-threshold: {}""".format(
+                return """
+        enabled: {}
+        threshold: {}""".format(
                     self.enabled, self.threshold
                 )
 
@@ -89,8 +89,8 @@ threshold: {}""".format(
                 return False
 
             def __str__(self):
-                return """Saturated:
-enabled: {}""".format(
+                return """
+        enabled: {}""".format(
                     self.enabled
                 )
 
@@ -114,8 +114,8 @@ enabled: {}""".format(
                 return False
 
             def __str__(self):
-                return """Reflection:
-enabled: {}""".format(
+                return """
+        enabled: {}""".format(
                     self.enabled
                 )
 
@@ -143,9 +143,9 @@ enabled: {}""".format(
                 return False
 
             def __str__(self):
-                return """Gaussian:
-enabled: {}
-sigma: {}""".format(
+                return """
+        enabled: {}
+        sigma: {}""".format(
                     self.enabled, self.sigma
                 )
 
@@ -185,12 +185,12 @@ sigma: {}""".format(
             return False
 
         def __str__(self):
-            return """Filters:
-contrast: {}
-outlier: {}
-saturated: {}
-reflection: {}
-gaussian: {}""".format(
+            return """
+    contrast: {}
+    outlier: {}
+    saturated: {}
+    reflection: {}
+    gaussian: {}""".format(
                 self.contrast,
                 self.outlier,
                 self.saturated,
@@ -247,7 +247,7 @@ gaussian: {}""".format(
         return False
 
     def __str__(self):
-        return """Settings:
+        return """--- # Settings
 bidirectional: {}
 blue_balance: {}
 brightness: {}


### PR DESCRIPTION
With some small changes, the string-representation of a Settings
object can be made to be both valid YAML and more human-readable.

The string-representation of a Settings can now e.g. be dumped to
a human-readable file and subsequently be parsed into a nested
dictionary with a simple yaml.load().

### Sample:
```
import zivid
s = zivid.Settings()
print(s)
```
#### Old result:
```
Settings:
bidirectional: False
blue_balance: 1.081
brightness: 1.0
exposure_time: 0:00:00.008333
filters: Filters:
contrast: Contrast:
enabled: True
threshold: 5.0
outlier: Outlier:
enabled: True
threshold: 5.0
saturated: Saturated:
enabled: True
reflection: Reflection:
enabled: False
gaussian: Gaussian:
enabled: False
sigma: 1.5
gain: 2.0
iris: 22
red_balance: 1.709
```
#### New result:
```
--- # Settings
bidirectional: False
blue_balance: 1.081
brightness: 1.0
exposure_time: 0:00:00.008333
filters: 
    contrast: 
        enabled: True
        threshold: 5.0
    outlier: 
        enabled: True
        threshold: 5.0
    saturated: 
        enabled: True
    reflection: 
        enabled: False
    gaussian: 
        enabled: False
        sigma: 1.5
gain: 2.0
iris: 22
red_balance: 1.709
```

The above is valid YAML, so that one can easily construct a nested dictionary from the serialization:
```
import yaml
yaml.load(str(s))
```
```
{'bidirectional': False,
 'blue_balance': 1.081,
 'brightness': 1.0,
 'exposure_time': 0.008333,
 'filters': {'contrast': {'enabled': True, 'threshold': 5.0},
  'outlier': {'enabled': True, 'threshold': 5.0},
  'saturated': {'enabled': True},
  'reflection': {'enabled': False},
  'gaussian': {'enabled': False, 'sigma': 1.5}},
 'gain': 2.0,
 'iris': 22,
 'red_balance': 1.709}
```