### PR TITLE
Enable nightly build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,10 @@
+schedules:
+- cron: "0 22 * * *"
+  displayName: Master nightly build
+  branches:
+    include:
+    - master
+  always: true
 jobs:
 - job: Windows
   pool:


### PR DESCRIPTION
Build the master branch nightly will ensure that we will quickly detect
if master is broken or not.