### PR TITLE
Removed doc strings from the C++ pybind11 wrapper layer

### DIFF
--- a/continuous-integration/linux/platform-dependent/arch/setup.sh
+++ b/continuous-integration/linux/platform-dependent/arch/setup.sh
@@ -25,7 +25,7 @@ function aur_install {
     for dep in $IGNORE_DEPS; do
         sed -i s/\'$dep\'//g PKGBUILD
     done
-    PKGEXT=.tar sudo -E -u nobody makepkg || exit $?
+    PKGEXT=.pkg.tar sudo -E -u nobody makepkg || exit $?
     pacman -U --noconfirm ./*$PACKAGE*.tar || exit $?
     popd || exit $?
     rm -r $TMP_DIR || exit $?

--- a/src/CameraRevision.cpp
+++ b/src/CameraRevision.cpp
@@ -6,14 +6,12 @@ namespace py = pybind11;
 
 namespace ZividPython
 {
-    MetaData wrapClass(pybind11::class_<Zivid::CameraRevision> pyClass)
+    void wrapClass(pybind11::class_<Zivid::CameraRevision> pyClass)
     {
         pyClass.def(py::init<>())
             .def(py::init<int, int>(), py::arg("major"), py::arg("minor"))
             .def(py::self == py::self) // NOLINT
             .def_property_readonly("major", &Zivid::CameraRevision::majorRevision)
             .def_property_readonly("minor", &Zivid::CameraRevision::minorRevision);
-
-        return { "Camera revision" };
     }
 } // namespace ZividPython

--- a/src/Environment.cpp
+++ b/src/Environment.cpp
@@ -5,10 +5,8 @@
 
 namespace ZividPython::Environment
 {
-    MetaData wrapAsSubmodule(pybind11::module &dest)
+    void wrapAsSubmodule(pybind11::module &dest)
     {
         dest.def("data_path", &Zivid::Environment::dataPath);
-
-        return { "Zivid environment, configured through environment variables" };
     }
 } // namespace ZividPython::Environment

--- a/src/Firmware.cpp
+++ b/src/Firmware.cpp
@@ -8,7 +8,7 @@ namespace py = pybind11;
 
 namespace ZividPython::Firmware
 {
-    MetaData wrapAsSubmodule(pybind11::module &dest)
+    void wrapAsSubmodule(pybind11::module &dest)
     {
         dest.def(
                 "update",
@@ -21,7 +21,5 @@ namespace ZividPython::Firmware
                 "is_up_to_date",
                 [](ReleasableCamera &camera) { return Zivid::Firmware::isUpToDate(camera.impl()); },
                 py::arg("camera"));
-
-        return { "Functions used to query the state and update the camera firmware" };
     }
 } // namespace ZividPython::Firmware

--- a/src/HDR.cpp
+++ b/src/HDR.cpp
@@ -10,7 +10,7 @@ namespace py = pybind11;
 
 namespace ZividPython::HDR
 {
-    MetaData wrapAsSubmodule(pybind11::module &dest)
+    void wrapAsSubmodule(pybind11::module &dest)
     {
         dest.def(
             "combine_frames",
@@ -24,7 +24,5 @@ namespace ZividPython::HDR
                 return ReleasableFrame{ Zivid::HDR::combineFrames(begin(frames), end(frames)) };
             },
             py::arg("frame_sequence"));
-
-        return { "Zivid environment, configured through environment variables" };
     }
 } // namespace ZividPython::HDR

--- a/src/PointCloud.cpp
+++ b/src/PointCloud.cpp
@@ -45,21 +45,10 @@ namespace
 
 namespace ZividPython
 {
-    MetaData wrapClass(pybind11::class_<Zivid::PointCloud> pyClass)
+    void wrapClass(pybind11::class_<Zivid::PointCloud> pyClass)
     {
         PYBIND11_NUMPY_DTYPE(DataType, x, y, z, contrast, b, g, r, a);
 
         pyClass.def(py::init<>()).def_buffer(makeBufferInfo);
-
-        return { R"(A point cloud with x,y,z, contrast and color data laid out on a 2D grid
-
-This class implements the `Buffer Protocol <docs.python.org/c-api/buffer.html>`_ and can
-be used in combinatins with modules supporting that protocol.
-
-NumPy is supported by using the `numpy.array` class like this:
-
-.. code-block:: python
-
-   np_point_cloud = numpy.array(point_cloud))" };
     }
 } // namespace ZividPython

--- a/src/ReleasableCamera.cpp
+++ b/src/ReleasableCamera.cpp
@@ -12,7 +12,7 @@ namespace py = pybind11;
 
 namespace ZividPython
 {
-    MetaData wrapClass(pybind11::class_<ReleasableCamera> pyClass)
+    void wrapClass(pybind11::class_<ReleasableCamera> pyClass)
     {
         pyClass.def(py::init<>())
             .def(py::self == py::self) // NOLINT
@@ -50,12 +50,5 @@ namespace ZividPython
                 },
                 py::arg("settings_collection"))
             .def_property_readonly("firmware_version", &ReleasableCamera::firmwareVersion);
-
-        return { R"(Interface to one Zivid camera
-
-See :class:`Settings` for a list of settings that can be configured in the camera.
-Capture single frames by calling :func:`capture` or start continuous frame recording
-:func:`start_live`.
-)" };
     }
 } // namespace ZividPython

--- a/src/ReleasableFrame.cpp
+++ b/src/ReleasableFrame.cpp
@@ -6,7 +6,7 @@ namespace py = pybind11;
 
 namespace ZividPython
 {
-    MetaData wrapClass(pybind11::class_<ReleasableFrame> pyClass)
+    void wrapClass(pybind11::class_<ReleasableFrame> pyClass)
     {
         pyClass.def(py::init<>())
             .def(py::init<const std::string &>(), py::arg("file_name"))
@@ -16,11 +16,5 @@ namespace ZividPython
             .def_property_readonly("state", &ReleasableFrame::state)
             .def_property_readonly("info", &ReleasableFrame::info)
             .def("get_point_cloud", &ReleasableFrame::getPointCloud);
-
-        return { R"(A frame captured by a Zivid camera
-
-Contains a Compute device point cloud and/or a CPU point cloud as well as
-calibration data, settings and state used by the API at time of the frame capture.
-)" };
     }
 } // namespace ZividPython

--- a/src/SingletonApplication.cpp
+++ b/src/SingletonApplication.cpp
@@ -8,7 +8,7 @@ namespace py = pybind11;
 
 namespace ZividPython
 {
-    MetaData wrapClass(pybind11::class_<SingletonApplication> pyClass)
+    void wrapClass(pybind11::class_<SingletonApplication> pyClass)
     {
         pyClass.def(py::init<>())
             .def("cameras", &SingletonApplication::cameras)
@@ -28,7 +28,5 @@ namespace ZividPython
                  &SingletonApplication::createFileCamera,
                  py::arg("frame_file"),
                  py::arg("settings") = Zivid::Settings{});
-
-        return { "Manager class for Zivid" };
     }
 } // namespace ZividPython

--- a/src/Version.cpp
+++ b/src/Version.cpp
@@ -5,14 +5,12 @@
 
 namespace ZividPython::Version
 {
-    MetaData wrapAsSubmodule(pybind11::module &dest)
+    void wrapAsSubmodule(pybind11::module &dest)
     {
         dest.attr("major") = std::stoi(ZIVID_VERSION_MAJOR);
         dest.attr("minor") = std::stoi(ZIVID_VERSION_MINOR);
         dest.attr("patch") = std::stoi(ZIVID_VERSION_PATCH);
         dest.attr("build") = ZIVID_VERSION_BUILD;
         dest.attr("full") = ZIVID_VERSION;
-
-        return { "Version information for the library" };
     }
 } // namespace ZividPython::Version

--- a/src/Wrapper.cpp
+++ b/src/Wrapper.cpp
@@ -18,7 +18,6 @@
 
 ZIVID_PYTHON_MODULE // NOLINT
 {
-    module.doc() = "Python bindings for the Zivid camera";
     module.attr("__version__") = pybind11::str(ZIVID_PYTHON_VERSION);
 
     ZIVID_PYTHON_WRAP_DATA_MODEL(module, Settings);

--- a/src/include/ZividPython/CameraRevision.h
+++ b/src/include/ZividPython/CameraRevision.h
@@ -5,5 +5,5 @@
 
 namespace ZividPython
 {
-    MetaData wrapClass(pybind11::class_<Zivid::CameraRevision> pyClass);
+    void wrapClass(pybind11::class_<Zivid::CameraRevision> pyClass);
 } // namespace ZividPython

--- a/src/include/ZividPython/DataModelWrapper.h
+++ b/src/include/ZividPython/DataModelWrapper.h
@@ -29,8 +29,7 @@ namespace ZividPython
                 .def(pybind11::self != pybind11::self) // NOLINT
                 .def_readonly_static("is_container", &Target::isContainer)
                 .def_readonly_static("name", &Target::name)
-                .def_readonly_static("path", &Target::path)
-                .doc() = Target::description;
+                .def_readonly_static("path", &Target::path);
 
             if constexpr(isRoot)
             {

--- a/src/include/ZividPython/Environment.h
+++ b/src/include/ZividPython/Environment.h
@@ -4,5 +4,5 @@
 
 namespace ZividPython::Environment
 {
-    MetaData wrapAsSubmodule(pybind11::module &dest);
+    void wrapAsSubmodule(pybind11::module &dest);
 } // namespace ZividPython::Environment

--- a/src/include/ZividPython/Firmware.h
+++ b/src/include/ZividPython/Firmware.h
@@ -4,5 +4,5 @@
 
 namespace ZividPython::Firmware
 {
-    MetaData wrapAsSubmodule(pybind11::module &dest);
+    void wrapAsSubmodule(pybind11::module &dest);
 } // namespace ZividPython::Firmware

--- a/src/include/ZividPython/HDR.h
+++ b/src/include/ZividPython/HDR.h
@@ -4,5 +4,5 @@
 
 namespace ZividPython::HDR
 {
-    MetaData wrapAsSubmodule(pybind11::module &dest);
+    void wrapAsSubmodule(pybind11::module &dest);
 } // namespace ZividPython::HDR

--- a/src/include/ZividPython/PointCloud.h
+++ b/src/include/ZividPython/PointCloud.h
@@ -5,5 +5,5 @@
 
 namespace ZividPython
 {
-    MetaData wrapClass(pybind11::class_<Zivid::PointCloud> pyClass);
+    void wrapClass(pybind11::class_<Zivid::PointCloud> pyClass);
 } // namespace ZividPython

--- a/src/include/ZividPython/ReleasableCamera.h
+++ b/src/include/ZividPython/ReleasableCamera.h
@@ -29,5 +29,5 @@ namespace ZividPython
         ZIVID_PYTHON_FORWARD_0_ARGS(userData)
     };
 
-    MetaData wrapClass(pybind11::class_<ReleasableCamera> pyClass);
+    void wrapClass(pybind11::class_<ReleasableCamera> pyClass);
 } // namespace ZividPython

--- a/src/include/ZividPython/ReleasableFrame.h
+++ b/src/include/ZividPython/ReleasableFrame.h
@@ -19,5 +19,5 @@ namespace ZividPython
         ZIVID_PYTHON_FORWARD_0_ARGS(info)
     };
 
-    MetaData wrapClass(pybind11::class_<ReleasableFrame> pyClass);
+    void wrapClass(pybind11::class_<ReleasableFrame> pyClass);
 } // namespace ZividPython

--- a/src/include/ZividPython/SingletonApplication.h
+++ b/src/include/ZividPython/SingletonApplication.h
@@ -29,5 +29,5 @@ namespace ZividPython
                                                 setting)
     };
 
-    MetaData wrapClass(pybind11::class_<SingletonApplication> pyClass);
+    void wrapClass(pybind11::class_<SingletonApplication> pyClass);
 } // namespace ZividPython

--- a/src/include/ZividPython/Version.h
+++ b/src/include/ZividPython/Version.h
@@ -4,5 +4,5 @@
 
 namespace ZividPython::Version
 {
-    MetaData wrapAsSubmodule(pybind11::module &dest);
+    void wrapAsSubmodule(pybind11::module &dest);
 } // namespace ZividPython::Version

--- a/src/include/ZividPython/Wrappers.h
+++ b/src/include/ZividPython/Wrappers.h
@@ -11,11 +11,6 @@
 
 namespace ZividPython
 {
-    struct MetaData
-    {
-        std::string doc;
-    };
-
     enum class WrapType
     {
         normal,
@@ -41,10 +36,6 @@ namespace ZividPython
         {
             pyClass.def_static("release", &Source::release);
         }
-
-        const auto metaData = wrapFunction(pyClass);
-
-        pyClass.doc() = metaData.doc;
     }
 
     template<typename WrapFunction>
@@ -55,35 +46,31 @@ namespace ZividPython
         std::string name{ nonLowercaseName };
         std::transform(begin(name), end(name), begin(name), ::tolower);
         auto submodule = dest.def_submodule(name.c_str());
-
-        const auto metaData = wrapFunction(submodule);
-
-        submodule.doc() = metaData.doc;
     }
 } // namespace ZividPython
 
 #define ZIVID_PYTHON_WRAP_CLASS(dest, name)                                                                            \
     ZividPython::wrapClass<Zivid::name, ZividPython::WrapType::normal>(                                                \
-        dest, static_cast<ZividPython::MetaData (*)(pybind11::class_<Zivid::name>)>(ZividPython::wrapClass), #name)
+        dest, static_cast<void (*)(pybind11::class_<Zivid::name>)>(ZividPython::wrapClass), #name)
 
 #define ZIVID_PYTHON_WRAP_CLASS_AS_RELEASABLE(dest, name)                                                              \
     ZividPython::wrapClass<ZividPython::Releasable##name, ZividPython::WrapType::releasable>(                          \
         dest,                                                                                                          \
-        static_cast<ZividPython::MetaData (*)(pybind11::class_<ZividPython::Releasable##name>)>(                       \
+        static_cast<void (*)(pybind11::class_<ZividPython::Releasable##name>)>(                       \
             ZividPython::wrapClass),                                                                                   \
         #name)
 
 #define ZIVID_PYTHON_WRAP_CLASS_AS_SINGLETON(dest, name)                                                               \
     ZividPython::wrapClass<ZividPython::Singleton##name, ZividPython::WrapType::singleton>(                            \
         dest,                                                                                                          \
-        static_cast<ZividPython::MetaData (*)(pybind11::class_<ZividPython::Singleton##name>)>(                        \
+        static_cast<void (*)(pybind11::class_<ZividPython::Singleton##name>)>(                        \
             ZividPython::wrapClass),                                                                                   \
         #name);
 
 #define ZIVID_PYTHON_WRAP_CLASS_BUFFER(dest, name)                                                                     \
     ZividPython::wrapClass<Zivid::name, ZividPython::WrapType::normal>(                                                \
         dest,                                                                                                          \
-        static_cast<ZividPython::MetaData (*)(pybind11::class_<Zivid::name>)>(ZividPython::wrapClass),                 \
+        static_cast<void (*)(pybind11::class_<Zivid::name>)>(ZividPython::wrapClass),                 \
         #name,                                                                                                         \
         pybind11::buffer_protocol())
 


### PR DESCRIPTION
These doc strings are not visible to the user of the moduel. We also
have dock strings in the python wrapper layer. Those are the ones
visible to end users.

Documenting the C++ wrapper provides little value and is not worth the
overhead of maintenance.