### PR TITLE
Version number is bumped to 0.9.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pkgutil import iter_modules
 
 # To be replaced by: from setuptools_scm import get_version
 def get_version():
-    return "0.9.1"
+    return "0.9.2"
 
 
 def _zivid_sdk_version():


### PR DESCRIPTION
Bumping version so we can release a new version to PYPI but still build against Zivid SDK 1.7.0. This release will contain HandEye API and 2D API.