### PR TITLE
Adjust README and setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Installation may take some time since the `setup.py` script will download additi
 
 If you are using a version of PIP older than version 19 please manually install the dependencies listed in [pyproject.toml](pyproject.toml) before installing zivid.
 
-    pip install scikit-build cmake ninja
+    pip install <packages listed in pyproject.toml>
     pip install zivid
 
 ## Quick Start

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ def _zivid_python_version():
 
 
 def _check_dependency(module_name, package_hint=None):
+    if package_hint is None:
+        package_hint = module_name
     if module_name not in [module[1] for module in iter_modules()]:
         raise ImportError(
             "Missing module '{}'. Please install '{}' manually or use PIP>=19 to handle build dependencies automatically (PEP 517).".format(
@@ -45,6 +47,7 @@ def _main():
     _check_dependency("skbuild", "scikit-build")
     _check_dependency("cmake")
     _check_dependency("ninja")
+    _check_dependency("conans", "conan")
 
     from skbuild import setup
 


### PR DESCRIPTION
- Changed instructions in README to refer directly to pyproject.toml.
This avoids the possibility of the instructions becoming out of sync.

- Adjusted _check_dependency() to avoid printing "None", like:
"Missing module 'cmake'. Please install 'None' manually or..."

- Added comment explaining why conan cannot be checked by
_check_dependency().