### PR TITLE
Improve error message when module build does not work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # Keep the two lists in sync
 requires = [
     "cmake",
+    "conan",
     "ninja",
     "scikit-build",
-    "conan",
     ]


### PR DESCRIPTION
This improve error messages during `pip install zivid` on systems
without binary packages and without C++17 support. This is implemented
as a nested exceptions where the outer most excetion gives a fix-it
hint.

I also sorted some dependency lists.

**Before**
![before](https://user-images.githubusercontent.com/5791955/70790699-e8b91e00-1d95-11ea-8930-627e366398ab.png)

**After**
![after](https://user-images.githubusercontent.com/5791955/70790701-e8b91e00-1d95-11ea-8e88-06b548d5f777.png)
