### PR TITLE
Enabling GitHub code owners feature for repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nedrebo @trym-b @eskaur


### PR DESCRIPTION
This patch sets the following uses as global code owners:

* nedrebo
* trym-b
* eskaur

When this is merged we will also require review from code owners when
making a pull request(PR) to master. This is done to because the
customer success team is now given write access to the repository to
be able to easily fix minor issues. However I want to restrict who can
approve PRs to master.

This change also gives us experience with the code owners feature, it
is likely something we want to enable for more repositories.