### PR TITLE
Fix broken CI tests with updated Intel OpenCL CPU driver

### DIFF
--- a/continuous-integration/linux/platform-dependent/arch/setup.sh
+++ b/continuous-integration/linux/platform-dependent/arch/setup.sh
@@ -2,6 +2,7 @@
 
 pacman -Syu --noconfirm --needed \
        clang \
+       clinfo \
        cmake \
        diffutils \
        fakeroot \

--- a/continuous-integration/linux/platform-dependent/common.sh
+++ b/continuous-integration/linux/platform-dependent/common.sh
@@ -1,0 +1,28 @@
+function install_opencl_cpu_runtime {
+    TMP_DIR=$(mktemp --tmpdir --directory zivid-setup-opencl-cpu-XXXX) || exit $?
+    pushd $TMP_DIR || exit $?
+    wget -q https://www.dropbox.com/s/h0txd04aqfluglq/l_opencl_p_18.1.0.015.tgz || exit $?
+    tar -xf l_opencl_p_18.1.0.015.tgz || exit $?
+    cd l_opencl_*/ || exit $?
+
+    cat > installer_config.cfg <<EOF
+# See silent.cfg in the .tgz for description of the options.
+ACCEPT_EULA=accept
+# 'yes' below is required because the installer officially supports only Ubuntu 16.04. However, it will
+# work fine on Ubuntu 18.04 and Fedora 30 as well.
+CONTINUE_WITH_OPTIONAL_ERROR=yes
+PSET_INSTALL_DIR=/opt/intel
+CONTINUE_WITH_INSTALLDIR_OVERWRITE=yes
+COMPONENTS=DEFAULTS
+PSET_MODE=install
+INTEL_SW_IMPROVEMENT_PROGRAM_CONSENT=no
+SIGNING_ENABLED=yes
+EOF
+    echo "Running Intel OpenCL driver installer."
+    echo "Note: Installer will warn about 'Unsupported operating system' if not run on Ubuntu 16.04."
+    echo "This warning can be ignored."
+    echo
+    ./install.sh --silent installer_config.cfg || exit $?
+    popd || exit $?
+    rm -r $TMP_DIR || exit $?
+}

--- a/continuous-integration/linux/platform-dependent/fedora-30/setup.sh
+++ b/continuous-integration/linux/platform-dependent/fedora-30/setup.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(realpath $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) )"
+
 dnf --assumeyes install \
     bsdtar \
+    clinfo \
     g++ \
     libatomic \
     python3-devel \
@@ -12,16 +15,12 @@ dnf --assumeyes install \
 alternatives --install /usr/bin/python python /usr/bin/python3 0 || exit $?
 alternatives --install /usr/bin/pip pip /usr/bin/pip3 0 || exit $?
 
-function install_opencl_cpu_runtime {
-    TMP_DIR=$(mktemp --tmpdir --directory zivid-setup-opencl-cpu-XXXX) || exit $?
-    pushd $TMP_DIR || exit $?
-    wget -nv https://www.dropbox.com/s/0cvg8fypylgal2m/opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz || exit $?
-    tar -xf opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz || exit $?
-    dnf install --assumeyes opencl_runtime_*/rpm/*.rpm || exit $?
-    popd || exit $?
-    rm -r $TMP_DIR || exit $?
-}
-
+source "$SCRIPT_DIR/../common.sh" || exit $?
+# Install OpenCL CPU runtime driver prerequisites
+dnf --assumeyes install \
+    numactl-libs \
+    redhat-lsb-core \
+    || exit $?
 install_opencl_cpu_runtime || exit $?
 
 function install_www_deb {

--- a/continuous-integration/linux/platform-dependent/ubuntu-16.04/setup.sh
+++ b/continuous-integration/linux/platform-dependent/ubuntu-16.04/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 export DEBIAN_FRONTEND=noninteractive
+SCRIPT_DIR="$(realpath $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) )"
 
 function apt-yes {
     apt-get --assume-yes "$@"
@@ -15,6 +16,7 @@ apt-yes update || exit $?
 
 apt-yes install \
     alien \
+    clinfo \
     g++-9 \
     python3-dev \
     python3-venv \
@@ -27,18 +29,9 @@ update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 0 || exit $?
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 0 || exit $?
 update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 0 || exit $?
 
-function install_opencl_cpu_runtime {
-    TMP_DIR=$(mktemp --tmpdir --directory zivid-setup-opencl-cpu-XXXX) || exit $?
-    pushd $TMP_DIR || exit $?
-    wget -nv https://www.dropbox.com/s/0cvg8fypylgal2m/opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz || exit $?
-    tar -xf opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz || exit $?
-    alien -i opencl_runtime_*/rpm/*.rpm || exit $?
-    mkdir -p /etc/OpenCL/vendors || exit $?
-    ls /opt/intel/opencl*/lib64/libintelocl.so > /etc/OpenCL/vendors/intel.icd || exit $?
-    popd || exit $?
-    rm -r $TMP_DIR || exit $?
-}
-
+source "$SCRIPT_DIR/../common.sh" || exit $?
+# Install OpenCL CPU runtime driver prerequisites
+apt-yes install libnuma-dev lsb-core || exit $?
 install_opencl_cpu_runtime || exit $?
 
 function install_www_deb {

--- a/continuous-integration/linux/platform-dependent/ubuntu-18.04/setup.sh
+++ b/continuous-integration/linux/platform-dependent/ubuntu-18.04/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 export DEBIAN_FRONTEND=noninteractive
+SCRIPT_DIR="$(realpath $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) )"
 
 function apt-yes {
     apt-get --assume-yes "$@"
@@ -11,6 +12,7 @@ apt-yes dist-upgrade || exit $?
 
 apt-yes install \
     alien \
+    clinfo \
     g++ \
     python3-dev \
     python3-venv \
@@ -21,18 +23,9 @@ apt-yes install \
 update-alternatives --install /usr/bin/python python /usr/bin/python3 0 || exit $?
 update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 0 || exit $?
 
-function install_opencl_cpu_runtime {
-    TMP_DIR=$(mktemp --tmpdir --directory zivid-setup-opencl-cpu-XXXX) || exit $?
-    pushd $TMP_DIR || exit $?
-    wget -nv https://www.dropbox.com/s/0cvg8fypylgal2m/opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz || exit $?
-    tar -xf opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz || exit $?
-    alien -i opencl_runtime_*/rpm/*.rpm || exit $?
-    mkdir -p /etc/OpenCL/vendors || exit $?
-    ls /opt/intel/opencl*/lib64/libintelocl.so > /etc/OpenCL/vendors/intel.icd || exit $?
-    popd || exit $?
-    rm -r $TMP_DIR || exit $?
-}
-
+source "$SCRIPT_DIR/../common.sh" || exit $?
+# Install OpenCL CPU runtime driver prerequisites
+apt-yes install libnuma-dev lsb-core || exit $?
 install_opencl_cpu_runtime || exit $?
 
 function install_www_deb {

--- a/continuous-integration/linux/setup.sh
+++ b/continuous-integration/linux/setup.sh
@@ -29,6 +29,9 @@ else
     exit 1
 fi
 
+echo "clinfo:"
+clinfo || exit $?
+
 install -D "$ROOT_DIR"/ZividAPIConfig.yml "$HOME"/.config/Zivid/API/Config.yml || exit $?
 
 echo Success! [$0]


### PR DESCRIPTION
The CI tests have been failing frequently with the following error:

> An OpenCL error occurred: Failed to get devices for context.
> ...
> [CL_INVALID_CONTEXT]

After some digging into this using clinfo, I discovered that device
name like "Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz" fails, while
"Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz" works. This suggests that
our current Intel OpenCL CPU driver does not support all the CPU's
available in Azure Pipelines.

Updating the Intel driver from version 16.1.1 to 18.1.0 fixes this
problem.

The prior method of manually installing the OpenCL CPU driver based on
the .tgz archive caused problems (clinfo would just hang). From this
commit we are instead using the install.sh script provided by Intel.

We now also print out "clinfo" after installing the driver. This will
help troubleshooting issues like these in the future.

Note that the OpenCL CPU driver officially support Ubuntu 16.04 and
not 18.04 or 20.04. However, the release notes states that "higher
versions are expected to be functional", and my own testing suggest
this works fine. We must set "CONTINUE_WITH_OPTIONAL_ERROR=yes" in
the .cfg file to allow non-supported OS'es.

This commit was based on apartridge's commit:
https://github.com/zivid/zivid-ros/commit/e951b7ce4aaeb5d2ce9a429f2f55afa86a8a7f31