### PR TITLE
Pin arch AUR zivid package version and fix broken OpenCL test setup

### DIFF
--- a/continuous-integration/linux/platform-dependent/arch/setup.sh
+++ b/continuous-integration/linux/platform-dependent/arch/setup.sh
@@ -18,9 +18,13 @@ pacman -Syu --noconfirm --needed \
 
 function aur_install {
     PACKAGE=$1; shift
+    VERSION_HASH=$1; shift
     IGNORE_DEPS=$*
     TMP_DIR=$(sudo -u nobody mktemp --tmpdir --directory zivid-python-aur-install-XXXX) || exit $?
     git clone https://aur.archlinux.org/$PACKAGE.git $TMP_DIR || exit $?
+    if [[ -n $VERSION_HASH ]] ; then
+        git --git-dir="$TMP_DIR/.git" --work-tree="$TMP_DIR" checkout $VERSION_HASH || exit $?
+    fi
     pushd $TMP_DIR || exit $?
     for dep in $IGNORE_DEPS; do
         sed -i s/\'$dep\'//g PKGBUILD
@@ -34,7 +38,7 @@ function aur_install {
 # Use so file from ncurses instead of ncurses5-compat-libs
 # as dependency for intel-opencl-runtime
 ln -s /usr/lib/libtinfo.so.{6,5} || exit $?
-aur_install intel-opencl-runtime ncurses5-compat-libs || exit $?
+aur_install intel-opencl-runtime "" ncurses5-compat-libs || exit $?
 
-aur_install zivid-telicam-driver || exit $?
-aur_install zivid || exit $?
+aur_install zivid-telicam-driver 48da46ee95cb679fd25149c251872a64817ff9ad || exit $?
+aur_install zivid f9c38eab6467f0d98f4602f0a5af0f90be07a37d || exit $?

--- a/continuous-integration/linux/platform-dependent/arch/setup.sh
+++ b/continuous-integration/linux/platform-dependent/arch/setup.sh
@@ -2,6 +2,7 @@
 
 pacman -Syu --noconfirm --needed \
        clang \
+       clinfo \
        cmake \
        diffutils \
        fakeroot \

--- a/continuous-integration/linux/platform-dependent/common.sh
+++ b/continuous-integration/linux/platform-dependent/common.sh
@@ -1,0 +1,28 @@
+function install_opencl_cpu_runtime {
+    TMP_DIR=$(mktemp --tmpdir --directory zivid-setup-opencl-cpu-XXXX) || exit $?
+    pushd $TMP_DIR || exit $?
+    wget -q https://www.dropbox.com/s/h0txd04aqfluglq/l_opencl_p_18.1.0.015.tgz || exit $?
+    tar -xf l_opencl_p_18.1.0.015.tgz || exit $?
+    cd l_opencl_*/ || exit $?
+
+    cat > installer_config.cfg <<EOF
+# See silent.cfg in the .tgz for description of the options.
+ACCEPT_EULA=accept
+# 'yes' below is required because the installer officially supports only Ubuntu 16.04. However, it will
+# work fine on Ubuntu 18.04 and Fedora 30 as well.
+CONTINUE_WITH_OPTIONAL_ERROR=yes
+PSET_INSTALL_DIR=/opt/intel
+CONTINUE_WITH_INSTALLDIR_OVERWRITE=yes
+COMPONENTS=DEFAULTS
+PSET_MODE=install
+INTEL_SW_IMPROVEMENT_PROGRAM_CONSENT=no
+SIGNING_ENABLED=yes
+EOF
+    echo "Running Intel OpenCL driver installer."
+    echo "Note: Installer will warn about 'Unsupported operating system' if not run on Ubuntu 16.04."
+    echo "This warning can be ignored."
+    echo
+    ./install.sh --silent installer_config.cfg || exit $?
+    popd || exit $?
+    rm -r $TMP_DIR || exit $?
+}

--- a/continuous-integration/linux/platform-dependent/common.sh
+++ b/continuous-integration/linux/platform-dependent/common.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 function install_opencl_cpu_runtime {
     TMP_DIR=$(mktemp --tmpdir --directory zivid-setup-opencl-cpu-XXXX) || exit $?
     pushd $TMP_DIR || exit $?

--- a/continuous-integration/linux/platform-dependent/fedora-30/setup.sh
+++ b/continuous-integration/linux/platform-dependent/fedora-30/setup.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(realpath $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) )"
+
 dnf --assumeyes install \
     bsdtar \
+    clinfo \
     g++ \
     libatomic \
     python3-devel \
@@ -12,16 +15,12 @@ dnf --assumeyes install \
 alternatives --install /usr/bin/python python /usr/bin/python3 0 || exit $?
 alternatives --install /usr/bin/pip pip /usr/bin/pip3 0 || exit $?
 
-function install_opencl_cpu_runtime {
-    TMP_DIR=$(mktemp --tmpdir --directory zivid-setup-opencl-cpu-XXXX) || exit $?
-    pushd $TMP_DIR || exit $?
-    wget -nv https://www.dropbox.com/s/0cvg8fypylgal2m/opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz || exit $?
-    tar -xf opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz || exit $?
-    dnf install --assumeyes opencl_runtime_*/rpm/*.rpm || exit $?
-    popd || exit $?
-    rm -r $TMP_DIR || exit $?
-}
-
+source "$SCRIPT_DIR/../common.sh" || exit $?
+# Install OpenCL CPU runtime driver prerequisites
+dnf --assumeyes install \
+    numactl-libs \
+    redhat-lsb-core \
+    || exit $?
 install_opencl_cpu_runtime || exit $?
 
 function install_www_deb {

--- a/continuous-integration/linux/platform-dependent/ubuntu-16.04/setup.sh
+++ b/continuous-integration/linux/platform-dependent/ubuntu-16.04/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 export DEBIAN_FRONTEND=noninteractive
+SCRIPT_DIR="$(realpath $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) )"
 
 function apt-yes {
     apt-get --assume-yes "$@"
@@ -15,6 +16,7 @@ apt-yes update || exit $?
 
 apt-yes install \
     alien \
+    clinfo \
     g++-9 \
     python3-dev \
     python3-venv \
@@ -27,18 +29,9 @@ update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 0 || exit $?
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 0 || exit $?
 update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 0 || exit $?
 
-function install_opencl_cpu_runtime {
-    TMP_DIR=$(mktemp --tmpdir --directory zivid-setup-opencl-cpu-XXXX) || exit $?
-    pushd $TMP_DIR || exit $?
-    wget -nv https://www.dropbox.com/s/0cvg8fypylgal2m/opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz || exit $?
-    tar -xf opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz || exit $?
-    alien -i opencl_runtime_*/rpm/*.rpm || exit $?
-    mkdir -p /etc/OpenCL/vendors || exit $?
-    ls /opt/intel/opencl*/lib64/libintelocl.so > /etc/OpenCL/vendors/intel.icd || exit $?
-    popd || exit $?
-    rm -r $TMP_DIR || exit $?
-}
-
+source "$SCRIPT_DIR/../common.sh" || exit $?
+# Install OpenCL CPU runtime driver prerequisites
+apt-yes install libnuma-dev lsb-core || exit $?
 install_opencl_cpu_runtime || exit $?
 
 function install_www_deb {

--- a/continuous-integration/linux/platform-dependent/ubuntu-18.04/setup.sh
+++ b/continuous-integration/linux/platform-dependent/ubuntu-18.04/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 export DEBIAN_FRONTEND=noninteractive
+SCRIPT_DIR="$(realpath $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) )"
 
 function apt-yes {
     apt-get --assume-yes "$@"
@@ -11,6 +12,7 @@ apt-yes dist-upgrade || exit $?
 
 apt-yes install \
     alien \
+    clinfo \
     g++ \
     python3-dev \
     python3-venv \
@@ -21,18 +23,9 @@ apt-yes install \
 update-alternatives --install /usr/bin/python python /usr/bin/python3 0 || exit $?
 update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 0 || exit $?
 
-function install_opencl_cpu_runtime {
-    TMP_DIR=$(mktemp --tmpdir --directory zivid-setup-opencl-cpu-XXXX) || exit $?
-    pushd $TMP_DIR || exit $?
-    wget -nv https://www.dropbox.com/s/0cvg8fypylgal2m/opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz || exit $?
-    tar -xf opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz || exit $?
-    alien -i opencl_runtime_*/rpm/*.rpm || exit $?
-    mkdir -p /etc/OpenCL/vendors || exit $?
-    ls /opt/intel/opencl*/lib64/libintelocl.so > /etc/OpenCL/vendors/intel.icd || exit $?
-    popd || exit $?
-    rm -r $TMP_DIR || exit $?
-}
-
+source "$SCRIPT_DIR/../common.sh" || exit $?
+# Install OpenCL CPU runtime driver prerequisites
+apt-yes install libnuma-dev lsb-core || exit $?
 install_opencl_cpu_runtime || exit $?
 
 function install_www_deb {

--- a/continuous-integration/linux/setup.sh
+++ b/continuous-integration/linux/setup.sh
@@ -29,6 +29,9 @@ else
     exit 1
 fi
 
+echo "clinfo:"
+clinfo || exit $?
+
 install -D "$ROOT_DIR"/ZividAPIConfig.yml "$HOME"/.config/Zivid/API/Config.yml || exit $?
 
 echo Success! [$0]

--- a/src/include/ZividPython/Releasable.h
+++ b/src/include/ZividPython/Releasable.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <optional>
+#include <stdexcept>
 
 #define ZIVID_PYTHON_FORWARD_0_ARGS_TEMPLATE_1_ARG_WRAP_RETURN(returnType, functionName, returnTypeTypename)           \
     auto functionName()                                                                                                \


### PR DESCRIPTION
Since updating zivid AUR packages, the current master does no longer
build on arch. Pinning the version makes arch build again.
This is required to get zivid-python to pass CI before the wrapper is
updated to work with API 2.0.

Also updated OpenCL setup in order not to fail when run in the CI.