### PR TITLE
Enable Ubuntu 20.04 tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,9 @@ jobs:
       ArchLinux:
         os: 'archlinux/base'
         command: './lint.sh'
+      Ubuntu2004:
+        os: 'ubuntu:20.04'
+        command: './test.sh'  
       Ubuntu1804:
         os: 'ubuntu:18.04'
         command: './test.sh'

--- a/continuous-integration/linux/platform-dependent/ubuntu-20.04/setup.sh
+++ b/continuous-integration/linux/platform-dependent/ubuntu-20.04/setup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+export DEBIAN_FRONTEND=noninteractive
+SCRIPT_DIR="$(realpath $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) )"
+
+function apt-yes {
+    apt-get --assume-yes "$@"
+}
+
+apt-yes update || exit $?
+apt-yes dist-upgrade || exit $?
+
+apt-yes install \
+    alien \
+    clinfo \
+    g++ \
+    python3-dev \
+    python3-venv \
+    python3-pip \
+    wget \
+    || exit $?
+
+update-alternatives --install /usr/bin/python python /usr/bin/python3 0 || exit $?
+update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 0 || exit $?
+
+source "$SCRIPT_DIR/../common.sh" || exit $?
+# Install OpenCL CPU runtime driver prerequisites
+apt-yes install libnuma-dev lsb-core || exit $?
+install_opencl_cpu_runtime || exit $?
+
+function install_www_deb {
+    TMP_DIR=$(mktemp --tmpdir --directory zivid-python-install-www-deb-XXXX) || exit $?
+    pushd $TMP_DIR || exit $?
+    wget -nv "$@" || exit $?
+    apt-yes install --fix-broken ./*deb || exit $?
+    popd || exit $?
+    rm -r $TMP_DIR || exit $?
+}
+
+install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/1.8.1+6967bc1b-1/u18/zivid-telicam-driver_3.0.1.1-1_amd64.deb || exit $?
+install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/1.8.1+6967bc1b-1/u18/zivid_1.8.1+6967bc1b-1_amd64.deb || exit $?


### PR DESCRIPTION
This commit ensures that zivid-python is built and tested on the latest
LTS version of Ubuntu, using the same Zivid SDK artifacts as Ubuntu
18.04.