### PR TITLE
Upgrade PIP packages to latest versions

### DIFF
--- a/continuous-integration/linux/lint.sh
+++ b/continuous-integration/linux/lint.sh
@@ -10,7 +10,10 @@ nonPublicPythonFiles=$(comm -23 <(echo $pythonFiles| tr " " "\n" |sort) \
 
 bashFiles=$(find "$ROOT_DIR" -name '*.sh')
 
-pip install --requirement "$SCRIPT_DIR/../python-requirements/lint.txt" || exit $?
+pip install \
+    --requirement "$SCRIPT_DIR/../python-requirements/lint.txt" \
+    --requirement "$SCRIPT_DIR/../python-requirements/test.txt" ||
+    exit $?
 
 echo Running non public pylint on:
 echo "$nonPublicPythonFiles"

--- a/continuous-integration/linux/test.sh
+++ b/continuous-integration/linux/test.sh
@@ -5,7 +5,7 @@ ROOT_DIR=$(realpath "$SCRIPT_DIR/../..")
 
 pip install --requirement "$SCRIPT_DIR/../python-requirements/test.txt" || exit $?
 
-python -m pytest "$ROOT_DIR" -c "$ROOT_DIR/pytest.ini" --unmarked || exit $?
+python -m pytest "$ROOT_DIR" -c "$ROOT_DIR/pytest.ini" || exit $?
 
 "$SCRIPT_DIR/run_samples.sh" || exit $?
 

--- a/continuous-integration/python-requirements/lint.txt
+++ b/continuous-integration/python-requirements/lint.txt
@@ -1,11 +1,6 @@
-black==19.3b0
-darglint==0.5.6
-flake8==3.7.7
-flake8-docstrings==1.3.0
-# Workaround fo https://gitlab.com/pycqa/flake8-docstrings/issues/36
-# This requirement can be removed when flake8-docstrings is fixed
-pydocstyle<4
-pylint==2.3.1
-pytest==4.6.4
-requests==2.22.0
-scikit-build==0.10.0
+black==19.10b0
+darglint==1.4.1
+flake8==3.8.3
+flake8-docstrings==1.5.0
+pylint==2.5.3
+scikit-build==0.11.1

--- a/continuous-integration/python-requirements/setup.txt
+++ b/continuous-integration/python-requirements/setup.txt
@@ -1,1 +1,1 @@
-requests==2.22.0
+requests==2.24.0

--- a/continuous-integration/python-requirements/test.txt
+++ b/continuous-integration/python-requirements/test.txt
@@ -1,5 +1,4 @@
-pytest==4.6.4
+pytest==5.4.3
 pytest-pythonpath==0.7.3
-pytest-timeout==1.3.3
-pytest-unmarked==1.1
-requests==2.22.0
+pytest-timeout==1.4.1
+requests==2.24.0

--- a/continuous-integration/windows/setup.py
+++ b/continuous-integration/windows/setup.py
@@ -30,7 +30,7 @@ def _install_pip_dependencies():
 
 
 def _install_zivid_sdk():
-    import requests
+    import requests  # pylint: disable=import-outside-toplevel
 
     with tempfile.TemporaryDirectory() as temp_dir:
         zivid_installer_url = "https://www.zivid.com/hubfs/softwarefiles/releases/1.8.1+6967bc1b-1/windows/ZividSetup_1.8.1+6967bc1b-1.exe"

--- a/modules/zivid/camera.py
+++ b/modules/zivid/camera.py
@@ -36,9 +36,12 @@ class Camera:
         Args:
             internal_camera: An internal Zivid camera instance
 
+        Raises:
+            TypeError: unsupported type provided for internal camera
+
         """
         if not isinstance(internal_camera, _zivid.Camera):
-            raise RuntimeError(
+            raise TypeError(
                 "Unsupported type for argument internal camera: {}, type: {}.".format(
                     internal_camera, type(internal_camera)
                 )
@@ -198,6 +201,9 @@ class Camera:
 
         Args:
             user_data: bytes
+
+        Raises:
+            TypeError: unsupported type provided for user data
 
         """
         if not isinstance(user_data, bytes):

--- a/modules/zivid/frame.py
+++ b/modules/zivid/frame.py
@@ -17,6 +17,9 @@ class Frame:  # pylint: disable=too-few-public-methods
         Args:
             file_name: a pathlib.Path instance or a string
 
+        Raises:
+            TypeError: unsupported type provided for file name
+
         """
         if isinstance(file_name, (str, Path)):
             self.__impl = _zivid.Frame(str(file_name))

--- a/modules/zivid/frame_2d.py
+++ b/modules/zivid/frame_2d.py
@@ -19,6 +19,9 @@ class Frame2D:
         Args:
             internal_frame_2d: internal 2D frame
 
+        Raises:
+            TypeError: unsupported type provided for internal 2d frame
+
         """
         if isinstance(internal_frame_2d, _zivid.Frame2D):
             self.__impl = internal_frame_2d

--- a/modules/zivid/image.py
+++ b/modules/zivid/image.py
@@ -13,9 +13,12 @@ class Image:
         Args:
             internal_image: an internal image
 
+        Raises:
+            TypeError: unsupported type provided for internal image
+
         """
         if not isinstance(internal_image, _zivid.Image):
-            raise ValueError(
+            raise TypeError(
                 "Unsupported type for argument internal_image. Got {}, expected {}".format(
                     type(internal_image), type(_zivid.Image)
                 )

--- a/modules/zivid/point_cloud.py
+++ b/modules/zivid/point_cloud.py
@@ -13,9 +13,12 @@ class PointCloud:
         Args:
             internal_point_cloud: a internal point cloud
 
+        Raises:
+            TypeError: unsupported type provided for internal point cloud
+
         """
         if not isinstance(internal_point_cloud, _zivid.PointCloud):
-            raise ValueError(
+            raise TypeError(
                 "Unsupported type for argument internal_point_cloud. Got {}, expected {}".format(
                     type(internal_point_cloud), type(_zivid.PointCloud)
                 )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 timeout = 300
-addopts = --strict-markers
+addopts = --strict-markers -m "not physical_camera"
 markers =
     physical_camera: requires physical camera to run
 python_paths=.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
+import tempfile
+import platform
+import subprocess
+from pathlib import Path
 from pkgutil import iter_modules
+from skbuild import setup
 
 # To be replaced by: from setuptools_scm import get_version
 def get_version():
@@ -55,13 +60,7 @@ def _check_dependency(module_name, package_hint=None):
 
 
 def _check_cpp17_compiler():
-    import tempfile
-    import platform
-    from pathlib import Path
-
     def run_process(args, **kwargs):
-        import subprocess
-
         try:
             process = subprocess.Popen(args, **kwargs)
             exit_code = process.wait()
@@ -112,8 +111,6 @@ def _main():
     _check_dependency("skbuild", "scikit-build")
 
     _check_cpp17_compiler()
-
-    from skbuild import setup
 
     setup(
         name="zivid",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,20 +1,22 @@
+import tempfile
+import datetime
+from random import randint, choice, uniform
+from pathlib import Path
+
 import pytest
+import zivid
+
 from scripts.sample_data import download_and_extract
 
 
 @pytest.fixture(name="application")
 def application_fixture():
-    import zivid
-
     with zivid.Application() as app:
         yield app
 
 
 @pytest.fixture(name="sample_data_file", scope="session")
 def sample_data_file_fixture():
-    from pathlib import Path
-    import tempfile
-
     with tempfile.TemporaryDirectory() as temp_dir:
         sample_data = Path(temp_dir) / "MiscObjects.zdf"
         download_and_extract(sample_data)
@@ -35,16 +37,12 @@ def physical_camera_fixture(application):
 
 @pytest.fixture(name="frame")
 def frame_fixture(application, sample_data_file):  # pylint: disable=unused-argument
-    import zivid
-
     with zivid.Frame(sample_data_file) as frame:
         yield frame
 
 
 @pytest.fixture(name="physical_camera_frame_2d")
 def physical_camera_frame_2d_fixture(physical_camera):
-    import zivid
-
     settings_2d = zivid.Settings2D()
     with physical_camera.capture_2d(settings_2d) as frame_2d:
         yield frame_2d
@@ -64,10 +62,6 @@ def point_cloud_fixture(frame):
 
 @pytest.fixture(name="random_settings")
 def random_settings_fixture():
-    import datetime
-    from random import randint, choice, uniform
-    import zivid
-
     heavily_modified_settings = zivid.Settings(
         bidirectional=choice([True, False]),
         blue_balance=uniform(1, 8),
@@ -97,8 +91,6 @@ def random_settings_fixture():
 def three_frames_fixture(
     application, sample_data_file  # pylint: disable=unused-argument
 ):
-    import zivid
-
     frames = [zivid.Frame(sample_data_file)] * 3
     yield frames
     for fram in frames:

--- a/test/converters/test_from_settings.py
+++ b/test/converters/test_from_settings.py
@@ -1,3 +1,6 @@
+# pylint: disable=import-outside-toplevel
+
+
 def test_to_internal_settings_to_settings_modified(random_settings):
     from zivid import Settings
     from zivid._settings_converter import to_settings, to_internal_settings

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-outside-toplevel
 import pytest
 
 

--- a/test/test_camera.py
+++ b/test/test_camera.py
@@ -1,16 +1,17 @@
+# pylint: disable=import-outside-toplevel
 import pytest
 
 
 def test_illegal_init(application):  # pylint: disable=unused-argument
     import zivid
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TypeError):
         zivid.camera.Camera("this should fail")
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TypeError):
         zivid.camera.Camera(None)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TypeError):
         zivid.camera.Camera(12345)
 
 

--- a/test/test_camera_capture.py
+++ b/test/test_camera_capture.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-outside-toplevel
 import pytest
 
 

--- a/test/test_camera_info.py
+++ b/test/test_camera_info.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-outside-toplevel
 import pytest
 
 

--- a/test/test_camera_state.py
+++ b/test/test_camera_state.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-outside-toplevel
 import pytest
 
 

--- a/test/test_camera_user_data.py
+++ b/test/test_camera_user_data.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-outside-toplevel
 import pytest
 
 

--- a/test/test_capture_assistant.py
+++ b/test/test_capture_assistant.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-outside-toplevel
 import datetime
 import pytest
 
@@ -66,7 +67,7 @@ def test_init_max_capture_time(application):  # pylint: disable=unused-argument
 
 
 def test_default_ambient_light_frequency(
-    application  # pylint: disable=unused-argument
+    application,  # pylint: disable=unused-argument
 ):
     from zivid.capture_assistant import SuggestSettingsParameters, AmbientLightFrequency
 

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -1,3 +1,6 @@
+# pylint: disable=import-outside-toplevel
+
+
 def test_data_path(application):  # pylint: disable=unused-argument
     import zivid
     import pathlib

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -1,3 +1,6 @@
+# pylint: disable=import-outside-toplevel
+
+
 def test_default_init_filters(application):  # pylint: disable=unused-argument
     import zivid
 

--- a/test/test_firmware.py
+++ b/test/test_firmware.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-outside-toplevel
 import pytest
 
 

--- a/test/test_frame.py
+++ b/test/test_frame.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-outside-toplevel
 import pytest
 
 

--- a/test/test_frame_2d.py
+++ b/test/test_frame_2d.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-outside-toplevel
 import pytest
 
 

--- a/test/test_frame_info.py
+++ b/test/test_frame_info.py
@@ -1,3 +1,6 @@
+# pylint: disable=import-outside-toplevel
+
+
 def test_timestamp():
     import datetime
     import zivid

--- a/test/test_hand_eye.py
+++ b/test/test_hand_eye.py
@@ -1,3 +1,6 @@
+# pylint: disable=import-outside-toplevel
+
+
 def test_init_pose():
     import numpy as np
     import zivid.hand_eye

--- a/test/test_hdr_combine_frames.py
+++ b/test/test_hdr_combine_frames.py
@@ -1,3 +1,6 @@
+# pylint: disable=import-outside-toplevel
+
+
 def test_list_one_element(frame):
     import zivid
     from zivid.hdr import combine_frames

--- a/test/test_image_2d.py
+++ b/test/test_image_2d.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-outside-toplevel
 import pytest
 
 

--- a/test/test_point_cloud.py
+++ b/test/test_point_cloud.py
@@ -1,3 +1,6 @@
+# pylint: disable=import-outside-toplevel
+
+
 def test_point_cloud_to_array(point_cloud):
     import numpy as np
 
@@ -64,8 +67,8 @@ def test_illegal_init(application):  # pylint: disable=unused-argument
     with pytest.raises(TypeError):
         zivid.PointCloud()  # pylint: disable=no-value-for-parameter
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         zivid.PointCloud("Should fail.")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         zivid.PointCloud(123)

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -1,3 +1,6 @@
+# pylint: disable=import-outside-toplevel
+
+
 def test_default_init_settings(application):  # pylint: disable=unused-argument
     import numbers
     import datetime

--- a/test/test_settings_2d.py
+++ b/test/test_settings_2d.py
@@ -1,3 +1,6 @@
+# pylint: disable=import-outside-toplevel
+
+
 def test_default_init_settings_2d(application):  # pylint: disable=unused-argument
     import numbers
     import datetime

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -1,3 +1,6 @@
+# pylint: disable=import-outside-toplevel
+
+
 def _is_version(sut):
     return isinstance(sut, str) and len(sut) > 0
 

--- a/test/test_zivid_module_content.py
+++ b/test/test_zivid_module_content.py
@@ -1,3 +1,6 @@
+# pylint: disable=import-outside-toplevel
+
+
 def test_import_zivid_globals_changes():
     before = sorted(globals().keys())
     import zivid  # pylint: disable=unused-import


### PR DESCRIPTION
Prework for upgrading zivid-python to be API 2.0 compatible.

When linting, the linter installs both linter and test dependencies,
or pylint will complain:
    ```
    E1101: Module 'pytest' has no 'helpers' member (no-member)
    ```

Removed unnecessary pip packages from lint requirements file.