### PR TITLE
Enable Windows CI tests

### DIFF
--- a/continuous-integration/windows/setup.py
+++ b/continuous-integration/windows/setup.py
@@ -1,6 +1,7 @@
 import tempfile
 import sys
 import subprocess
+import shutil
 from pathlib import Path
 
 
@@ -42,9 +43,33 @@ def _install_zivid_sdk():
         _run_process((str(zivid_installer), "/S"))
 
 
+def _install_intel_opencl_runtime():
+    import requests  # pylint: disable=import-outside-toplevel
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        intel_opencl_runtime_url = "https://www.dropbox.com/s/09bk2nx31hzrupf/opencl_runtime_18.1_x64_setup-20200625-090300.msi?raw=1"
+        print("Downloading {}".format(intel_opencl_runtime_url), flush=True)
+        opencl_runtime = Path(temp_dir) / "opencl_runtime.msi"
+        response = requests.get(intel_opencl_runtime_url)
+        opencl_runtime.write_bytes(response.content)
+        print("Installing {}".format(opencl_runtime), flush=True)
+        _run_process(("msiexec", "/i", str(opencl_runtime), "/passive"))
+
+
+def _write_zivid_cpu_configuration_file():
+    api_config = Path() / "ZividAPIConfig.yml"
+    target_location = Path(
+        r"C:\Users\VssAdministrator\AppData\Local\Zivid\API\Config.yml"
+    )
+    target_location.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(str(api_config), str(target_location))
+
+
 def _main():
     _install_pip_dependencies()
+    _install_intel_opencl_runtime()
     _install_zivid_sdk()
+    _write_zivid_cpu_configuration_file()
 
 
 if __name__ == "__main__":

--- a/test/test_samples.py
+++ b/test/test_samples.py
@@ -1,11 +1,21 @@
+import platform
+
 import pytest
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason=r"python: can't open file 'D:\a\samples\sample_capture_from_file.py': [Errno 2] No such file or directory",
+)
 def test_capture_from_file(sample_data_file):
     pytest.helpers.run_sample(
         name="capture_from_file", working_directory=sample_data_file.parent
     )
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason=r"python: can't open file 'D:\a\samples\sample_print_version_info.py': [Errno 2] No such file or directory",
+)
 def test_print_version_info():
     pytest.helpers.run_sample(name="print_version_info")


### PR DESCRIPTION
In order to run tests on Windows, Intel OpenCL runtime needs to be
installed to run the tests on a compute device. It is also required to
create a configuration file so that the tests are run on the CPU instead
of a GPU (since there are no GPU available in azure-pipelines)

Added update environment script in order to load the latest envrionement
variables set by `Zivid-SDK` after successful installation. `PATH`
environment variable must be updated befre running the tests.

Ignored sample testing for windows, because of the following error:
```
python: can't open file 'D:\a\samples\sample_print_version_info.py': [Errno 2] No such file or directory
```

Ignored `winreg` import error, this module is not available on Linux