### PR TITLE
Avoid mismatch in Python version

### DIFF
--- a/continuous-integration/windows/test.py
+++ b/continuous-integration/windows/test.py
@@ -48,6 +48,8 @@ def _install_pip_dependencies():
     print("Installing python test requirements", flush=True)
     _run_process(
         (
+            "python",
+            "-m",
             "pip",
             "install",
             "--requirement",


### PR DESCRIPTION
It is possible that calling pip directly does not install packages for the Python accessed with Python directly. To avoid mismatch, call pip via Python.
`python -m pip install -r requirements.txt`
vs
`pip install -r requirements.txt`