### PR TITLE
Bump pip packages

### DIFF
--- a/continuous-integration/python-requirements/lint.txt
+++ b/continuous-integration/python-requirements/lint.txt
@@ -1,6 +1,6 @@
 black==19.10b0
-darglint==1.4.1
+darglint==1.5.3
 flake8==3.8.3
 flake8-docstrings==1.5.0
-pylint==2.5.3
+pylint==2.6.0
 scikit-build==0.11.1

--- a/continuous-integration/python-requirements/test.txt
+++ b/continuous-integration/python-requirements/test.txt
@@ -1,5 +1,5 @@
-pytest==5.4.3
+pytest==6.0.1
 pytest-helpers-namespace==2019.1.8
 pytest-pythonpath==0.7.3
-pytest-timeout==1.4.1
+pytest-timeout==1.4.2
 requests==2.24.0


### PR DESCRIPTION
 * `darglint` from 1.4.1 to 1.5.3
 * `pylint` from 2.5.3 to 2.6.0
 * `pytest` from 5.4.3 to 6.0.1
 * `pytest-timeout` from 1.4.1 to 1.4.2