### PR TITLE
Fix errors from __del__ methods

### DIFF
--- a/modules/zivid/application.py
+++ b/modules/zivid/application.py
@@ -67,7 +67,12 @@ class Application:
 
     def release(self):
         """Release the underlying resources."""
-        self.__impl.release()
+        try:
+            impl = self.__impl
+        except AttributeError:
+            pass
+        else:
+            impl.release()
 
     def __enter__(self):
         return self

--- a/modules/zivid/camera.py
+++ b/modules/zivid/camera.py
@@ -117,7 +117,12 @@ class Camera:
 
     def release(self):
         """Release the underlying resources."""
-        self.__impl.release()
+        try:
+            impl = self.__impl
+        except AttributeError:
+            pass
+        else:
+            impl.release()
 
     def __enter__(self):
         return self

--- a/modules/zivid/frame.py
+++ b/modules/zivid/frame.py
@@ -102,7 +102,12 @@ class Frame:  # pylint: disable=too-few-public-methods
 
     def release(self):
         """Release the underlying resources."""
-        self.__impl.release()
+        try:
+            impl = self.__impl
+        except AttributeError:
+            pass
+        else:
+            impl.release()
 
     def __enter__(self):
         return self

--- a/modules/zivid/frame_2d.py
+++ b/modules/zivid/frame_2d.py
@@ -82,7 +82,12 @@ class Frame2D:
 
     def release(self):
         """Release the underlying resources."""
-        self.__impl.release()
+        try:
+            impl = self.__impl
+        except AttributeError:
+            pass
+        else:
+            impl.release()
 
     def __enter__(self):
         return self

--- a/modules/zivid/image.py
+++ b/modules/zivid/image.py
@@ -69,7 +69,12 @@ class Image:
 
     def release(self):
         """Release the underlying resources."""
-        self.__impl.release()
+        try:
+            impl = self.__impl
+        except AttributeError:
+            pass
+        else:
+            impl.release()
 
     def __enter__(self):
         return self

--- a/modules/zivid/point_cloud.py
+++ b/modules/zivid/point_cloud.py
@@ -101,7 +101,12 @@ class PointCloud:
 
     def release(self):
         """Release the underlying resources."""
-        self.__impl.release()
+        try:
+            impl = self.__impl
+        except AttributeError:
+            pass
+        else:
+            impl.release()
 
     def __enter__(self):
         return self


### PR DESCRIPTION
Currently, if e.g. a PointCloud gets scheduled for deletion before
self.__impl has been set (e.g. due to an error in __init__),
an AttributeError would be thrown from __del__. Exceptions are
ignored when coming from __del__, but may still cause an error
message to be written to stderr, which looks bad.

The problem can be illustrated by running:
```
pytest -c ./pytest.ini test/test_point_cloud.py --capture=no -k test_illegal_init
```

This commit solves this by checking that self.__impl exists before
calling release() on it.