### PR TITLE
Fix Windows build

### DIFF
--- a/src/ReleasableArray2D.cpp
+++ b/src/ReleasableArray2D.cpp
@@ -23,7 +23,7 @@ namespace
         static_assert(depth > 0, "Depth of array must be one or higher");
         static_assert(sizeof(WrapperType) * depth == sizeof(NativeType), "Unexpected data format");
 
-        constexpr size_t dim = (depth == 1) ? 2 : 3;
+        constexpr py::ssize_t dim = (depth == 1) ? 2 : 3;
         const auto shape = { arrayWrapper.impl().height(), arrayWrapper.impl().width(), depth };
         const auto strides = { sizeof(WrapperType) * arrayWrapper.impl().width() * depth,
                                sizeof(WrapperType) * depth,
@@ -33,8 +33,8 @@ namespace
                                sizeof(WrapperType),
                                py::format_descriptor<WrapperType>::format(),
                                dim,
-                               std::vector<size_t>(shape.begin(), shape.begin() + dim),
-                               std::vector<size_t>(strides.begin(), strides.begin() + dim));
+                               std::vector<py::ssize_t>(shape.begin(), shape.begin() + dim),
+                               std::vector<py::ssize_t>(strides.begin(), strides.begin() + dim));
     }
 
     template<typename NativeType>

--- a/src/ReleasableImage.cpp
+++ b/src/ReleasableImage.cpp
@@ -10,25 +10,27 @@ namespace
     {
         using WrapperType = uint8_t;
         using NativeType = Zivid::ColorRGBA;
-        constexpr size_t dim = 3;
-        constexpr size_t depth = 4;
 
-        static_assert(sizeof(WrapperType) * depth == sizeof(NativeType));
+        constexpr py::ssize_t dim = 3;
+        constexpr py::ssize_t depth = 4;
+        constexpr py::ssize_t dataSize = sizeof(WrapperType);
+
+        static_assert(dataSize * depth == sizeof(NativeType));
         static_assert(std::is_same_v<WrapperType, decltype(NativeType::r)>);
         static_assert(std::is_same_v<WrapperType, decltype(NativeType::g)>);
         static_assert(std::is_same_v<WrapperType, decltype(NativeType::b)>);
         static_assert(std::is_same_v<WrapperType, decltype(NativeType::a)>);
 
         auto *dataPtr = static_cast<void *>(const_cast<NativeType *>(image.impl().data()));
+        const auto height = static_cast<py::ssize_t>(image.impl().height());
+        const auto width = static_cast<py::ssize_t>(image.impl().width());
 
-        return py::buffer_info{
-            dataPtr,
-            sizeof(WrapperType),
-            py::format_descriptor<WrapperType>::format(),
-            dim,
-            { image.impl().height(), image.impl().width(), depth },
-            { sizeof(WrapperType) * image.impl().width() * depth, sizeof(WrapperType) * depth, sizeof(WrapperType) }
-        };
+        return py::buffer_info{ dataPtr,
+                                dataSize,
+                                py::format_descriptor<WrapperType>::format(),
+                                dim,
+                                { height, width, depth },
+                                { dataSize * width * depth, dataSize * depth, dataSize } };
     }
 } // namespace
 


### PR DESCRIPTION
Windows compilers complained about some implicit casting being done
in ReleaseableImage.cpp/ReleasableArray2D.cpp.