### PR TITLE
Decrease precision requirement of hand-eye test

### DIFF
--- a/test/calibration/test_hand_eye.py
+++ b/test/calibration/test_hand_eye.py
@@ -74,7 +74,7 @@ def test_eyetohand_calibration(
     assert isinstance(transform_returned, np.ndarray)
     assert transform_returned.shape == (4, 4)
     np.testing.assert_array_almost_equal(
-        transform_returned, handeye_eth_transform, decimal=4
+        transform_returned, handeye_eth_transform, decimal=3
     )
 
     # Check returned residuals


### PR DESCRIPTION
The reference matrix was based on a Linux run, and the outcome of this
algorithm seems to be a bit sensitive to the compiler/platform (since
the test-dataset has quite few poses). Changing the tolerance to let
this pass test on Windows.