### PR TITLE
Bump Ubuntu 16.04 to Python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Zivid Python is the official Python package for Zivid 3D cameras. Read more abou
 
 ### Dependencies
 
-* [Python](https://www.python.org/) version 3.5 or higher
+* [Python](https://www.python.org/) version 3.6 or higher
 * [Zivid SDK](https://www.zivid.com/downloads) version 2.2.0 (see [here](https://zivid.atlassian.net/wiki/spaces/ZividKB/pages/59080712/Zivid+Software+Installation) for help)
 * [Compiler](doc/CompilerInstallation.md) with C++17 support
 
@@ -148,10 +148,12 @@ Please visit [Zivid Knowledge Base](http://help.zivid.com) for general informati
 | :--------------- | :------------------| :---------------- |
 | Ubuntu 20.04     | 3.8                | 2.2.0             |
 | Ubuntu 18.04     | 3.6                | 2.2.0             |
-| Ubuntu 16.04     | 3.5                | 2.2.0             |
+| Ubuntu 16.04     | 3.6*               | 2.2.0             |
 | Fedora 30        | 3.7                | 2.2.0             |
 | Windows 10       | 3.6, 3.7, 3.8, 3.9 | 2.2.0             |
 | Arch Linux       | latest             | 2.2.0             |
+
+[*] Warning: This is not the default Python3 for Ubuntu 16.04. The default is Python3.5, which is deprecated and not supported by Zivid Python.
 
 [header-image]: https://www.zivid.com/hubfs/softwarefiles/images/zivid-generic-github-header.png
 [ci-badge]: https://img.shields.io/github/workflow/status/zivid/zivid-python/Main%20CI%20workflow/master

--- a/continuous-integration/linux/platform-dependent/ubuntu-16.04/setup.sh
+++ b/continuous-integration/linux/platform-dependent/ubuntu-16.04/setup.sh
@@ -12,26 +12,30 @@ apt-yes dist-upgrade || exit $?
 
 apt-yes install software-properties-common || exit $?
 add-apt-repository -y ppa:ubuntu-toolchain-r/test || exit $?
+add-apt-repository --yes ppa:deadsnakes/ppa
 apt-yes update || exit $?
 
 apt-yes install \
     clinfo \
     g++-9 \
-    python3-dev \
-    python3-venv \
-    python3-pip \
+    python3.6-dev \
+    python3.6-venv \
     wget \
+    curl \
     || exit $?
 
-update-alternatives --install /usr/bin/python python /usr/bin/python3 0 || exit $?
-update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 0 || exit $?
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 0 || exit $?
-update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 0 || exit $?
+curl https://bootstrap.pypa.io/get-pip.py | python3.6
 
 source "$SCRIPT_DIR/../common.sh" || exit $?
 # Install OpenCL CPU runtime driver prerequisites
 apt-yes install libnuma-dev lsb-core || exit $?
 install_opencl_cpu_runtime || exit $?
+
+update-alternatives --install /usr/bin/python python /usr/bin/python3.6 0 || exit $?
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 0 || exit $?
+update-alternatives --install /usr/bin/pip pip /usr/local/bin/pip3.6 0 || exit $?
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 0 || exit $?
+update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 0 || exit $?
 
 function install_www_deb {
     TMP_DIR=$(mktemp --tmpdir --directory zivid-python-install-www-deb-XXXX) || exit $?


### PR DESCRIPTION
The default python3 of Ubuntu 16.04 (python3.5) has been end-of-life
since September 2020. Recently there has been some upgrades to
dependencies on PyPI that causes zivid-python to stop working with
U16/python3.5. This includes numpy, as well as pip itself (it breaks
itself when upgrading if on python3.5).

While it may be possible to work around this to retain U16/python3.5
support, it seems more reasonable to drop python3.5 support altogether
at this point. This commit adjusts ubuntu-16.04/setup.sh so that
python3.6 is used instead.

It was also discovered that the installation of lsb-core now resets g++
to point to g++-5, so the update-alternatives lines were moved further
down in ubuntu-16.04/setup.sh.