### PR TITLE
Add DetectionResult.centroid()

### DIFF
--- a/modules/zivid/_calibration/detector.py
+++ b/modules/zivid/_calibration/detector.py
@@ -37,6 +37,16 @@ class DetectionResult:
         """
         return self.__impl.valid()
 
+    def centroid(self):
+        """Get the centroid of the detected feature points.
+
+        Will throw an exception if the DetectionResult is not valid.
+
+        Returns:
+            A 1D array containing the X, Y and Z coordinates of the centroid
+        """
+        return self.__impl.centroid()
+
     def __bool__(self):
         return bool(self.__impl)
 

--- a/src/Calibration/Detector.cpp
+++ b/src/Calibration/Detector.cpp
@@ -1,6 +1,7 @@
 #include <Zivid/Calibration/Detector.h>
 
 #include <ZividPython/Calibration/Detector.h>
+#include <ZividPython/Matrix.h>
 
 #include <pybind11/pybind11.h>
 
@@ -10,6 +11,9 @@ namespace ZividPython
 {
     void wrapClass(pybind11::class_<Zivid::Calibration::DetectionResult> pyClass)
     {
-        pyClass.def("valid", &Zivid::Calibration::DetectionResult::valid);
+        pyClass.def("valid", &Zivid::Calibration::DetectionResult::valid)
+            .def("centroid", [](const Zivid::Calibration::DetectionResult &detectionResult) {
+                return Conversion::toPyVector(detectionResult.centroid());
+            });
     }
 } // namespace ZividPython

--- a/src/include/ZividPython/Matrix.h
+++ b/src/include/ZividPython/Matrix.h
@@ -2,6 +2,7 @@
 
 #include "pybind11/eigen.h"
 #include <Zivid/Matrix.h>
+#include <Zivid/Point.h>
 
 namespace ZividPython::Conversion
 {
@@ -15,5 +16,10 @@ namespace ZividPython::Conversion
     auto toPy(const Zivid::Matrix<T, rows, cols> &source)
     {
         return Eigen::Matrix<T, rows, cols, Eigen::RowMajor>{ &(source(0, 0)) };
+    }
+
+    inline auto toPyVector(const Zivid::PointXYZ &source)
+    {
+        return Eigen::Vector3f{ source.x, source.y, source.z };
     }
 } // namespace ZividPython::Conversion

--- a/test/calibration/test_calibration_basics.py
+++ b/test/calibration/test_calibration_basics.py
@@ -11,6 +11,7 @@ def test_pose(transform):
 
 
 def test_detect_feature_points(checkerboard_frames):
+    import numpy as np
     import zivid
 
     frame = checkerboard_frames[0]
@@ -20,3 +21,7 @@ def test_detect_feature_points(checkerboard_frames):
     assert bool(detection_result)
     assert detection_result.valid()
     assert str(detection_result)
+    centroid = detection_result.centroid()
+    assert isinstance(centroid, np.ndarray)
+    assert centroid.shape == (3,)
+    np.testing.assert_allclose(centroid, [-67.03593, 71.17018, 906.348], rtol=1e-6)


### PR DESCRIPTION
A small new feature that was introduced in SDK 2.2,
DetectionResult.centroid(), was not included in the corresponding
release of zivid-python. This commit add that feature.