### PR TITLE
CMake: Update pybind11 to 2.6.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,10 @@ endif()
 
 include(${CMAKE_BINARY_DIR}/conan.cmake)
 
+set(PYBIND11_VERSION 2.6.1)
 conan_cmake_run(REQUIRES 
                     eigen/3.3.7@conan/stable
-                    pybind11/2.3.0@conan/stable
+                    pybind11/${PYBIND11_VERSION}
                 BASIC_SETUP)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -25,7 +26,7 @@ if(MSVC)
 endif()
 
 find_package(Zivid ${ZIVID_SDK_VERSION} EXACT COMPONENTS Core REQUIRED)
-find_package(pybind11 2.3.0 REQUIRED)
+find_package(pybind11 ${PYBIND11_VERSION} REQUIRED)
 find_package(Eigen3 3.3 REQUIRED)
 
 add_subdirectory(src)


### PR DESCRIPTION
2.6.1 is the latest version on conan. The changelog for pybind11
is at https://pybind11.readthedocs.io/en/stable/changelog.html