### PR TITLE
CI: Enable CI for external pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,9 @@ name: Main CI workflow
 # Note: If the workflow name is changed, the CI badge URL in the README must also be updated
 
 on:
-  push:       # Push trigger runs on any pushed branch.
-  schedule:   # Scheduled trigger runs on the latest commit on the default branch.
+  push:         # Push trigger runs on any pushed branch.
+  pull_request: # External pull requests will trigger the Github Actions.
+  schedule:     # Scheduled trigger runs on the latest commit on the default branch.
     - cron:  '0 22 * * *'
 
 jobs:


### PR DESCRIPTION
Previously, if someone forked this repo and created a pull request from
that external repo, Github Actions would not be triggered. This makes it
difficult to know if the external changes will break this repo or not.

This commit ensures that external PRs now will trigger CI builds.