### PR TITLE
Add Fedora33 (python3.9) to CI test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: ["ubuntu:18.04", "ubuntu:20.04", "fedora:30", "archlinux/base"]
+        os: ["ubuntu:18.04", "ubuntu:20.04", "fedora:30", "fedora:33", "archlinux/base"]
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Please visit [Zivid Knowledge Base](http://help.zivid.com) for general informati
 | Ubuntu 20.04     | 3.8                | 2.2.0             |
 | Ubuntu 18.04     | 3.6                | 2.2.0             |
 | Fedora 30        | 3.7                | 2.2.0             |
+| Fedora 33        | 3.9                | 2.2.0             |
 | Windows 10       | 3.6, 3.7, 3.8, 3.9 | 2.2.0             |
 | Arch Linux       | latest             | 2.2.0             |
 

--- a/continuous-integration/linux/platform-dependent/fedora-33/setup.sh
+++ b/continuous-integration/linux/platform-dependent/fedora-33/setup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(realpath $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) )"
+
+dnf --assumeyes install \
+    bsdtar \
+    clinfo \
+    g++ \
+    libatomic \
+    python3-devel \
+    python3-pip \
+    wget \
+    || exit $?
+
+alternatives --install /usr/bin/python python /usr/bin/python3 0 || exit $?
+alternatives --install /usr/bin/pip pip /usr/bin/pip3 0 || exit $?
+
+source "$SCRIPT_DIR/../common.sh" || exit $?
+# Install OpenCL CPU runtime driver prerequisites
+dnf --assumeyes install \
+    numactl-libs \
+    redhat-lsb-core \
+    || exit $?
+install_opencl_cpu_runtime || exit $?
+
+function install_www_deb {
+    TMP_DIR=$(mktemp --tmpdir --directory zivid-python-install-www-deb-XXXX) || exit $?
+    pushd $TMP_DIR || exit $?
+    wget -nv "$@" || exit $?
+    ar x ./*deb || exit $?
+    bsdtar -xf data.tar.*z -C / || exit $?
+    ldconfig || exit $?
+    popd || exit $?
+    rm -r $TMP_DIR || exit $?
+}
+
+install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/u18/zivid-telicam-driver_3.0.1.1-3_amd64.deb || exit $?
+install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/u18/zivid_2.2.0+f0867d62-1_amd64.deb || exit $?

--- a/doc/CompilerInstallation.md
+++ b/doc/CompilerInstallation.md
@@ -6,7 +6,7 @@ This document contains instruction for how to install a compatible compiler for 
 
     apt install g++
 
-## Fedora 30
+## Fedora 30 and Fedora 33
 
     dnf install g++
 


### PR DESCRIPTION
This commit adds Fedora33 to the CI test matrix, which means that we now
officially support/test python3.9 on Linux. We already supported
python3.9 on Windows.