### PR TITLE
CI: Use runc v1.0.0-rc93 on hosts with archlinux containers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,13 +14,20 @@ jobs:
         uses: actions/checkout@v2
         with:
           lfs: false
+      # TODO(#122): Remove step when issue #122 is solved
+      - name: update runc # https://github.com/actions/virtual-environments/issues/2698#issuecomment-779262068
+        run: |
+          sudo apt-get install --assume-yes libseccomp-dev
+          git clone https://github.com/opencontainers/runc
+          cd runc && git checkout v1.0.0-rc93 && make -j`nproc` && sudo make install
+          cd .. && rm --recursive runc
       - name: Build and lint on Archlinux
-        run: | 
+        run: |
           docker run \
               --volume $PWD:/host \
               --workdir /host/continuous-integration/linux \
               --env "PYTHONDONTWRITEBYTECODE=1" \
-              archlinux/base \
+              archlinux/archlinux:base-devel \
               bash -c "./setup.sh && ./build.sh && ./lint.sh"
 
   create-source-distribution:
@@ -31,7 +38,7 @@ jobs:
         with:
           lfs: false
       - name: Create source distribution
-        run: | 
+        run: |
           docker run \
               --volume $PWD:/host \
               --workdir /host/continuous-integration/linux \
@@ -79,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: ["ubuntu:18.04", "ubuntu:20.04", "fedora:30", "fedora:33", "archlinux/base"]
+        os: ["ubuntu:18.04", "ubuntu:20.04", "fedora:30", "fedora:33", "archlinux/archlinux:base-devel"]
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -90,8 +97,16 @@ jobs:
         with:
           name: source-distribution
           path: dist
+      # TODO(#122): Remove step when issue #122 is solved
+      - name: update runc # https://github.com/actions/virtual-environments/issues/2698#issuecomment-779262068
+        if: startsWith(matrix.os, 'archlinux')
+        run: |
+          sudo apt-get install --assume-yes libseccomp-dev
+          git clone https://github.com/opencontainers/runc
+          cd runc && git checkout v1.0.0-rc93 && make -j`nproc` && sudo make install
+          cd .. && rm --recursive runc
       - name: Install from source-distribution and test
-        run: | 
+        run: |
           docker run \
               --volume $PWD:/host \
               --workdir /host/continuous-integration/linux \


### PR DESCRIPTION
Can be reverted after these issues are fixed.

https://github.com/actions/virtual-environments/issues/2658
https://github.com/moby/moby/pull/42014