### PR TITLE
Fix bug where __bool__ -> True when valid() -> False

### DIFF
--- a/src/include/ZividPython/Traits.h
+++ b/src/include/ZividPython/Traits.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <type_traits>
+
+#if __has_include(<experimental/type_traits>)
+#    include <experimental/type_traits>
+#else
+namespace Detail
+{
+    // Fallback implementation of is_detected for compilers lacking <experimental/type_traits>
+    struct nonesuch
+    {
+        ~nonesuch() = delete;
+        nonesuch(nonesuch const &) = delete;
+        void operator=(nonesuch const &) = delete;
+    };
+
+    template<class Default, class AlwaysVoid, template<class...> class Op, class... Args>
+    struct detector
+    {
+        using value_t = std::false_type;
+        using type = Default;
+    };
+
+    template<class Default, template<class...> class Op, class... Args>
+    struct detector<Default, std::void_t<Op<Args...>>, Op, Args...>
+    {
+        using value_t = std::true_type;
+        using type = Op<Args...>;
+    };
+} // namespace Detail
+#endif
+
+namespace ZividPython
+{
+#if __has_include(<experimental/type_traits>)
+    // Has the experimental header, so just use that.
+    template<template<class...> class Op, class... Args>
+    using is_detected = typename std::experimental::is_detected<Op, Args...>;
+#else
+    // Use fallback implementation.
+    template<template<class...> class Op, class... Args>
+    using is_detected = typename Detail::detector<Detail::nonesuch, void, Op, Args...>::value_t;
+#endif
+} // namespace ZividPython

--- a/src/include/ZividPython/Wrappers.h
+++ b/src/include/ZividPython/Wrappers.h
@@ -10,6 +10,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <ZividPython/Traits.h>
 #include <ZividPython/Wrapper.h>
 
 #include <pybind11/pybind11.h>
@@ -18,6 +19,9 @@ namespace ZividPython
 {
     namespace
     {
+        template<typename T>
+        using bool_t = decltype(static_cast<bool>(std::declval<T>()));
+
         /// Inserts underscore on positive case flank and before negative case flank:
         /// ZividSDKVersion -> zivid_sdk_version
         std::string toSnakeCase(const std::string upperCamelCase)
@@ -72,6 +76,11 @@ namespace ZividPython
         auto pyClass = pybind11::class_<Source>{ dest, exposedName, tags... }
                            .def("to_string", &Source::toString)
                            .def("__repr__", &Source::toString);
+
+        if constexpr(is_detected<bool_t, Source>::value)
+        {
+            pyClass.def("__bool__", &Source::operator bool);
+        }
 
         if constexpr(WrapType::releasable == wrapType)
         {


### PR DESCRIPTION
The classes in the calibration API have the following implementation on
the front-end,
```
def __bool__(self):
    return bool(self.__impl)
```
which was intended to represent the corresponding boolean operator on
the C++ API level. However, the boolean operator of the `__impl`s were
never overridden on the Pybind11 level, so they instead defaulted to
some behavior that seemingly always returns True, and is independent of
the `operator bool` in the C++ API. This caused the following kind of
bugs in the Python API
```
detection_result.valid() # False
bool(detection_result)   # True
```
This commit fixes this by explicitly hooking up the `__bool__` of the
Pybind11-generated classes to the `operator bool` of the C++ classes.
This yields behavior that is identical to the C++ API, as intended.

No unit-tests are added for this because instantiating invalid
calibration objects like DetectionResult requires running
detect_feature_points with a non-checkerboard point-cloud, and this
would unreasonably slow down the CI.