### PR TITLE
Revert "CI: Enable CI for external pull requests"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,8 @@ name: Main CI workflow
 # Note: If the workflow name is changed, the CI badge URL in the README must also be updated
 
 on:
-  push:         # Push trigger runs on any pushed branch.
-  pull_request: # External pull requests will trigger the Github Actions.
-  schedule:     # Scheduled trigger runs on the latest commit on the default branch.
+  push:       # Push trigger runs on any pushed branch.
+  schedule:   # Scheduled trigger runs on the latest commit on the default branch.
     - cron:  '0 22 * * *'
 
 jobs:


### PR DESCRIPTION
The reverted commit caused two builds whenever you pushed with a PR
open, which I had hoped would not happen.

This reverts commit dc0b8b8848a68b9a61b53e4938adfe70a5080a5e.