### PR TITLE
DataModelWrapper::toSnakeCase: Take string_view

### DIFF
--- a/src/include/ZividPython/DataModelWrapper.h
+++ b/src/include/ZividPython/DataModelWrapper.h
@@ -156,8 +156,7 @@ namespace ZividPython
 
                     using MemberType = std::remove_const_t<std::remove_reference_t<decltype(member)>>;
 
-                    std::string name{ MemberType::name };
-                    name = toSnakeCase(name);
+                    const std::string name = toSnakeCase(MemberType::name);
 
                     pyClass.def_property(
                         name.c_str(),

--- a/src/include/ZividPython/Wrappers.h
+++ b/src/include/ZividPython/Wrappers.h
@@ -42,7 +42,7 @@ namespace ZividPython
             std::stringstream ss;
             ss << char(tolower(upperCamelCase[0]));
 
-            for(auto i = 1; i < upperCamelCase.size(); ++i)
+            for(size_t i = 1; i < upperCamelCase.size(); ++i)
             {
                 if(isupper(upperCamelCase[i]))
                 {
@@ -54,12 +54,8 @@ namespace ZividPython
                     {
                         ss << "_";
                     }
-                    ss << char(tolower(upperCamelCase[i]));
                 }
-                else
-                {
-                    ss << char(upperCamelCase[i]);
-                }
+                ss << char(tolower(upperCamelCase[i]));
             }
             return ss.str();
         }

--- a/src/include/ZividPython/Wrappers.h
+++ b/src/include/ZividPython/Wrappers.h
@@ -15,6 +15,8 @@
 
 #include <pybind11/pybind11.h>
 
+#include <string_view>
+
 namespace ZividPython
 {
     namespace
@@ -24,7 +26,7 @@ namespace ZividPython
 
         /// Inserts underscore on positive case flank and before negative case flank:
         /// ZividSDKVersion -> zivid_sdk_version
-        std::string toSnakeCase(const std::string upperCamelCase)
+        std::string toSnakeCase(std::string_view upperCamelCase)
         {
             if(upperCamelCase.empty())
             {
@@ -33,7 +35,9 @@ namespace ZividPython
 
             if(!isupper(upperCamelCase[0]))
             {
-                throw std::runtime_error{ "First character of string: '" + upperCamelCase + "' is not capitalized" };
+                std::stringstream msg;
+                msg << "First character of string: '" << upperCamelCase << "' is not capitalized";
+                throw std::runtime_error{ msg.str() };
             }
             std::stringstream ss;
             ss << char(tolower(upperCamelCase[0]));
@@ -105,8 +109,8 @@ namespace ZividPython
                                   const WrapFunction &wrapFunction,
                                   const char *nonLowercaseName)
     {
-        std::string name{ nonLowercaseName };
-        auto submodule = dest.def_submodule(toSnakeCase(name).c_str());
+        const std::string name = toSnakeCase(nonLowercaseName);
+        auto submodule = dest.def_submodule(name.c_str());
         wrapFunction(submodule);
     }
 } // namespace ZividPython

--- a/src/include/ZividPython/Wrappers.h
+++ b/src/include/ZividPython/Wrappers.h
@@ -37,7 +37,7 @@ namespace ZividPython
             {
                 std::stringstream msg;
                 msg << "First character of string: '" << upperCamelCase << "' is not capitalized";
-                throw std::runtime_error{ msg.str() };
+                throw std::invalid_argument{ msg.str() };
             }
             std::stringstream ss;
             ss << char(tolower(upperCamelCase[0]));


### PR DESCRIPTION
This function does not modify its string argument,
i.e. can use std::string_view, assuming C++17.
This avoids implicit std::string temporaries.

Also fixes a use-after-free of the form:

    toSnakeCase(name).c_str()

This aligns the function with the one in SDK,
including a couple of unrelated changes:

* Loop variable type: int → size_t (would satisfy gcc -Wsign-compare)
* The call to tolower can be made unconditional due to idempotence.

Implements #93