### PR TITLE
Notify Teams channel upon CI failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,11 @@ jobs:
               --env "PYTHONDONTWRITEBYTECODE=1" \
               archlinux/archlinux:base  \
               bash -c "./setup.sh && ./build.sh && ./lint.sh"
+      - name: Notify Teams
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        env:
+          CI_FAILURE_TEAMS_HOOK: ${{ secrets.CI_FAILURE_TEAMS_HOOK }}
+        run: python continuous-integration/notification/notify_teams.py --status ${{ job.status }}
 
   create-source-distribution:
     runs-on: ubuntu-latest
@@ -44,6 +49,11 @@ jobs:
           name: source-distribution
           path: dist/zivid*.tar.gz
           retention-days: 1
+      - name: Notify Teams
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        env:
+          CI_FAILURE_TEAMS_HOOK: ${{ secrets.CI_FAILURE_TEAMS_HOOK }}
+        run: python continuous-integration/notification/notify_teams.py --status ${{ job.status }}
 
   create-windows-binary-distribution:
     runs-on: windows-2016
@@ -73,6 +83,11 @@ jobs:
           name: bdist-win-python${{matrix.python-version}}
           path: dist/zivid*.whl
           retention-days: 1
+      - name: Notify Teams
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        env:
+          CI_FAILURE_TEAMS_HOOK: ${{ secrets.CI_FAILURE_TEAMS_HOOK }}
+        run: python continuous-integration/notification/notify_teams.py --status ${{ job.status }}
 
   test-linux-source-distribution:
     needs: create-source-distribution
@@ -98,6 +113,11 @@ jobs:
               --env "PYTHONDONTWRITEBYTECODE=1" \
               ${{matrix.os}} \
               bash -c "./setup.sh && ./build-and-install-source-distribution.sh && ./test.sh"
+      - name: Notify Teams
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        env:
+          CI_FAILURE_TEAMS_HOOK: ${{ secrets.CI_FAILURE_TEAMS_HOOK }}
+        run: python continuous-integration/notification/notify_teams.py --status ${{ job.status }}
 
   test-windows-binary-distribution:
     needs: create-windows-binary-distribution
@@ -125,6 +145,11 @@ jobs:
         run: python continuous-integration\windows\install_binary_distribution.py
       - name: Test
         run: python continuous-integration\windows\test.py
+      - name: Notify Teams
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        env:
+          CI_FAILURE_TEAMS_HOOK: ${{ secrets.CI_FAILURE_TEAMS_HOOK }}
+        run: python continuous-integration/notification/notify_teams.py --status ${{ job.status }}
 
   deploy:
     needs: [lint, test-linux-source-distribution, test-windows-binary-distribution]
@@ -151,3 +176,8 @@ jobs:
         with:
           name: distributions_all
           path: distribution/
+      - name: Notify Teams
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        env:
+          CI_FAILURE_TEAMS_HOOK: ${{ secrets.CI_FAILURE_TEAMS_HOOK }}
+        run: python continuous-integration/notification/notify_teams.py --status ${{ job.status }}

--- a/continuous-integration/notification/notify_teams.py
+++ b/continuous-integration/notification/notify_teams.py
@@ -1,0 +1,64 @@
+import argparse
+import os
+import requests
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--status", required=True, help="Job status", type=str)
+    return parser.parse_args()
+
+
+def _main() -> None:
+    args = _args()
+
+    job = os.environ["GITHUB_JOB"]
+    branch = "/".join(os.environ["GITHUB_REF"].split("/")[2:])
+    workflow = os.environ["GITHUB_WORKFLOW"]
+    run_sha = os.environ["GITHUB_SHA"]
+    run_number = os.environ["GITHUB_RUN_NUMBER"]
+
+    server_url = os.environ["GITHUB_SERVER_URL"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    run_id = os.environ["GITHUB_RUN_ID"]
+    workflow_url = f"{server_url}/{repo}/actions/runs/{run_id}"
+    webhook_url = os.environ["CI_FAILURE_TEAMS_HOOK"]
+
+    payload = {
+        "@type": "MessageCard",
+        "@context": "http://schema.org/extensions",
+        "themeColor": "00D7CD",
+        "summary": f"{job} {args.status} on {branch}",
+        "sections": [
+            {
+                "activityTitle": f"{branch} {args.status}!",
+                "activitySubtitle": f"In workflow '{workflow}', job '{job}'",
+                "facts": [
+                    {"name": "Sha", "value": run_sha},
+                    {"name": "Run", "value": run_number},
+                ],
+            }
+        ],
+        "potentialAction": [
+            {
+                "@type": "ActionCard",
+                "name": "Actions",
+                "actions": [
+                    {
+                        "@type": "OpenUri",
+                        "name": "Go to GitHub Actions",
+                        "targets": [{"os": "default", "uri": workflow_url}],
+                    }
+                ],
+            }
+        ],
+    }
+    request = requests.post(webhook_url, json=payload)
+    try:
+        request.raise_for_status()
+    except requests.HTTPError as ex:
+        raise RuntimeError("Failed to post Teams notification") from ex
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
Notify Teams channel on the `secrets.CI_FAILURE_TEAMS_HOOK` webhook url
if a job in the CI workflow fails.

---
Here's an example of the notification one will get if the `lint` job in the CI
workflow fails.

![zivid-python-teams-notification](https://user-images.githubusercontent.com/21991610/129580088-324d17c2-3b83-458b-8318-677e7008aa9d.png)
