### PR TITLE
Eigen: Bump version to 3.3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(${CMAKE_BINARY_DIR}/conan.cmake)
 
 conan_cmake_run(
     REQUIRES
-        eigen/3.3.7@conan/stable
+        eigen/3.3.9
         pybind11/2.6.1
     CMAKE_TARGETS
     BASIC_SETUP)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,7 +44,7 @@ target_link_libraries(${PROJECT_NAME}
     PRIVATE Zivid::Core
             Python3::Module
             CONAN_PKG::pybind11
-            CONAN_PKG::Eigen3
+            CONAN_PKG::eigen
 )
 
 install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION modules/${PROJECT_NAME})


### PR DESCRIPTION
Previously eigen was provided by this repo:
https://github.com/conan-community/conan-eigen
Now it has been moved to: https://github.com/conan-io/conan-center-index

Also bumped eigen from 3.3.7 to 3.3.9.

Special thanks to @erikschuitema for providing this fix.

Closes #139