### PR TITLE
Bump linting tools

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,6 @@
 [MESSAGES CONTROL]
-disable=duplicate-code # Triggers on data-models
-
+disable=duplicate-code, # Triggers on data-models
+        consider-using-f-string # Keep .format() as long as we want unofficial python3.5 support
 [FORMAT]
 max-line-length=120
 

--- a/.pylintrc-internal
+++ b/.pylintrc-internal
@@ -1,6 +1,6 @@
 [MESSAGES CONTROL]
 disable=missing-docstring,
-        duplicate-code # Triggers on data-models
+        consider-using-f-string # Keep .format() as long as we want unofficial python3.5 support
 
 [FORMAT]
 max-line-length=150 # Generated code for data-models will sometimes have long lines.

--- a/.pylintrc-tests
+++ b/.pylintrc-tests
@@ -1,5 +1,10 @@
 [MESSAGES CONTROL]
-disable=missing-docstring,import-outside-toplevel,duplicate-code,unused-argument,pointless-statement
+disable=missing-docstring,
+        import-outside-toplevel,
+        duplicate-code,
+        unused-argument,
+        pointless-statement,
+        consider-using-f-string # Keep .format() as long as we want unofficial python3.5 support
 
 [FORMAT]
 max-line-length=120

--- a/continuous-integration/python-requirements/lint.txt
+++ b/continuous-integration/python-requirements/lint.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile continuous-integration/python-requirements/lint.in
 #
-astroid==2.5
+astroid==2.8.0
     # via pylint
 black==21.9b0
     # via -r continuous-integration/python-requirements/lint.in
 click==8.0.1
     # via black
-darglint==1.5.3
+darglint==1.8.0
     # via -r continuous-integration/python-requirements/lint.in
 distro==1.6.0
     # via scikit-build
-flake8==3.8.3
+flake8==3.9.2
     # via
     #   -r continuous-integration/python-requirements/lint.in
     #   flake8-docstrings
-flake8-docstrings==1.5.0
+flake8-docstrings==1.6.0
     # via -r continuous-integration/python-requirements/lint.in
 isort==5.9.3
     # via pylint
@@ -35,14 +35,16 @@ packaging==21.0
 pathspec==0.9.0
     # via black
 platformdirs==2.4.0
-    # via black
-pycodestyle==2.6.0
+    # via
+    #   black
+    #   pylint
+pycodestyle==2.7.0
     # via flake8
 pydocstyle==6.1.1
     # via flake8-docstrings
-pyflakes==2.2.0
+pyflakes==2.3.1
     # via flake8
-pylint==2.6.0
+pylint==2.11.1
     # via -r continuous-integration/python-requirements/lint.in
 pyparsing==2.4.7
     # via packaging
@@ -57,7 +59,10 @@ toml==0.10.2
 tomli==1.2.1
     # via black
 typing-extensions==3.10.0.2
-    # via black
+    # via
+    #   astroid
+    #   black
+    #   pylint
 wheel==0.37.0
     # via scikit-build
 wrapt==1.12.1

--- a/continuous-integration/windows/common.py
+++ b/continuous-integration/windows/common.py
@@ -10,10 +10,10 @@ def repo_root():
 def run_process(args, env=None, workdir=None):
     sys.stdout.flush()
     try:
-        process = subprocess.Popen(args, env=env, cwd=workdir)
-        exit_code = process.wait()
-        if exit_code != 0:
-            raise RuntimeError("Wait failed with exit code {}".format(exit_code))
+        with subprocess.Popen(args, env=env, cwd=workdir) as process:
+            exit_code = process.wait()
+            if exit_code != 0:
+                raise RuntimeError("Wait failed with exit code {}".format(exit_code))
     except Exception as ex:
         raise type(ex)("Process failed: '{}'.".format(" ".join(args))) from ex
     finally:

--- a/modules/zivid/camera.py
+++ b/modules/zivid/camera.py
@@ -3,10 +3,10 @@ from zivid.frame import Frame
 from zivid.frame_2d import Frame2D
 import zivid
 from zivid.settings_2d import Settings2D
-import zivid._settings_converter as _settings_converter
-import zivid._settings2_d_converter as _settings_2d_converter
-import zivid._camera_state_converter as _camera_state_converter
-import zivid._camera_info_converter as _camera_info_converter
+from zivid import _settings_converter
+from zivid import _settings2_d_converter
+from zivid import _camera_state_converter
+from zivid import _camera_info_converter
 import _zivid
 
 
@@ -62,7 +62,7 @@ class Camera:
         if isinstance(settings, Settings2D):
             return Frame2D(
                 self.__impl.capture(
-                    _settings_2d_converter.to_internal_settings2_d(settings)
+                    _settings2_d_converter.to_internal_settings2_d(settings)
                 )
             )
         raise TypeError("Unsupported settings type: {}".format(type(settings)))

--- a/modules/zivid/capture_assistant.py
+++ b/modules/zivid/capture_assistant.py
@@ -2,7 +2,7 @@
 import datetime
 
 import _zivid
-import zivid._settings_converter as _settings_converter
+from zivid import _settings_converter
 from zivid._capture_assistant_suggest_settings_parameters_converter import (
     to_internal_capture_assistant_suggest_settings_parameters,
 )

--- a/modules/zivid/frame.py
+++ b/modules/zivid/frame.py
@@ -2,10 +2,10 @@
 from pathlib import Path
 import _zivid
 
-import zivid._settings_converter as _settings_converter
-import zivid._camera_state_converter as _camera_state_converter
-import zivid._camera_info_converter as _camera_info_converter
-import zivid._frame_info_converter as _frame_info_converter
+from zivid import _settings_converter
+from zivid import _camera_state_converter
+from zivid import _camera_info_converter
+from zivid import _frame_info_converter
 from zivid.point_cloud import PointCloud
 
 

--- a/modules/zivid/frame_2d.py
+++ b/modules/zivid/frame_2d.py
@@ -1,9 +1,9 @@
 """Contains the Frame class."""
 import _zivid
 
-import zivid._settings2_d_converter as _settings_converter
-import zivid._camera_state_converter as _camera_state_converter
-import zivid._frame_info_converter as _frame_info_converter
+from zivid import _settings2_d_converter
+from zivid import _camera_state_converter
+from zivid import _frame_info_converter
 from zivid.image import Image
 
 
@@ -51,7 +51,7 @@ class Frame2D:
         Returns:
             A Settings2D instance
         """
-        return _settings_converter.to_settings2_d(self.__impl.settings)
+        return _settings2_d_converter.to_settings2_d(self.__impl.settings)
 
     @property
     def state(self):

--- a/samples/sample_calibrate_eye_to_hand.py
+++ b/samples/sample_calibrate_eye_to_hand.py
@@ -37,7 +37,7 @@ def _main():
     camera = app.connect_camera()
 
     current_pose_id = 0
-    calibration_inputs = list()
+    calibration_inputs = []
     calibrate = False
 
     while not calibrate:

--- a/setup.py
+++ b/setup.py
@@ -67,10 +67,12 @@ def _check_dependency(module_name, package_hint=None):
 def _check_cpp17_compiler():
     def run_process(args, **kwargs):
         try:
-            process = subprocess.Popen(args, **kwargs)
-            exit_code = process.wait()
-            if exit_code != 0:
-                raise RuntimeError("Wait failed with exit code {}".format(exit_code))
+            with subprocess.Popen(args, **kwargs) as process:
+                exit_code = process.wait()
+                if exit_code != 0:
+                    raise RuntimeError(
+                        "Wait failed with exit code {}".format(exit_code)
+                    )
         except Exception as ex:
             raise type(ex)("Process failed: '{}'.".format(" ".join(args))) from ex
 
@@ -121,7 +123,7 @@ def _main():
         name="zivid",
         version=_zivid_python_version(),
         description="Defining the Future of 3D Machine Vision",
-        long_description=open("README.md").read(),
+        long_description=Path("README.md").read_text(encoding="utf-8"),
         long_description_content_type="text/markdown",
         url="https://www.zivid.com",
         author="Zivid AS",


### PR DESCRIPTION
This commit does the following:
- Bump linting tools with `pip-compile --upgrade`.
- Update code to conform with new rules.

We ignore the "consider-using-f-string" rule because we do not want to
intentionally break the unofficial support for Ubuntu 16.04 / python3.5
yet. (f-strings were introduced in python3.6)