### PR TITLE
Minor readme fix

### DIFF
--- a/doc/CompilerInstallation.md
+++ b/doc/CompilerInstallation.md
@@ -2,11 +2,11 @@
 
 This document contains instruction for how to install a compatible compiler for compilation of the Zivid Python package.
 
-## Ubuntu 18.04 and 20.04
+## Ubuntu
 
     apt install g++
 
-## Fedora 30 and Fedora 33
+## Fedora
 
     dnf install g++
 


### PR DESCRIPTION
I noticed the Fedora compiler installation instructions were out of date.

Instead of adding the missing versions, I opted to remove all the
versions to reduce the risk of similar regressions in the future.