### PR TITLE
Add experimental camera intrinsics API

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -22,4 +22,5 @@ per-file-ignores =
     settings_2d.py:D101,D102,D106,D107
     camera_state.py:D101,D102,D106,D107
     camera_info.py:D101,D102,D106,D107
+    camera_intrinsics.py:D101,D102,D106,D107
     frame_info.py:D101,D102,D106,D107

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,10 @@
 [MESSAGES CONTROL]
 disable=duplicate-code, # Triggers on data-models
         consider-using-f-string # Keep .format() as long as we want unofficial python3.5 support
+
+[BASIC]
+good-names=i,j,k,ex,cx,cy,fx,fy,k1,k2,k3,p1,p2
+
 [FORMAT]
 max-line-length=120
 

--- a/.pylintrc-internal
+++ b/.pylintrc-internal
@@ -3,6 +3,8 @@ disable=missing-docstring,
         consider-using-f-string, # Keep .format() as long as we want unofficial python3.5 support
         duplicate-code, # Might have to be permanently disabled because of the code generation
 
+[BASIC]
+good-names=i,j,k,ex,cx,cy,fx,fy,k1,k2,k3,p1,p2
 
 [FORMAT]
 max-line-length=150

--- a/continuous-integration/code-generation/datamodel_frontend_generator.py
+++ b/continuous-integration/code-generation/datamodel_frontend_generator.py
@@ -710,6 +710,7 @@ def generate_all_datamodels(dest_dir: Path) -> None:
             "_suggest_settings_parameters.py",
             ["datetime"],
         ),
+        (_zivid.CameraIntrinsics, "camera_intrinsics.py", []),
     ]:
         _generate_datamodel_frontend(
             internal_class=internal_class,

--- a/modules/_zivid/__init__.py
+++ b/modules/_zivid/__init__.py
@@ -43,6 +43,7 @@ try:
         Array2DPointZ,
         Array2DSNR,
         Camera,
+        CameraIntrinsics,
         CameraState,
         firmware,
         calibration,

--- a/modules/zivid/__init__.py
+++ b/modules/zivid/__init__.py
@@ -21,3 +21,4 @@ from zivid.sdk_version import SDKVersion
 from zivid.settings import Settings
 from zivid.settings_2d import Settings2D
 from zivid.camera_info import CameraInfo
+from zivid.camera_intrinsics import CameraIntrinsics

--- a/modules/zivid/camera_intrinsics.py
+++ b/modules/zivid/camera_intrinsics.py
@@ -1,0 +1,506 @@
+"""Auto generated, do not edit."""
+# pylint: disable=too-many-lines,protected-access,too-few-public-methods,too-many-arguments,line-too-long,missing-function-docstring,missing-class-docstring,too-many-branches,too-many-boolean-expressions
+import _zivid
+
+
+class CameraIntrinsics:
+    class CameraMatrix:
+        def __init__(
+            self,
+            cx=_zivid.CameraIntrinsics.CameraMatrix.CX().value,
+            cy=_zivid.CameraIntrinsics.CameraMatrix.CY().value,
+            fx=_zivid.CameraIntrinsics.CameraMatrix.FX().value,
+            fy=_zivid.CameraIntrinsics.CameraMatrix.FY().value,
+        ):
+
+            if isinstance(
+                cx,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._cx = _zivid.CameraIntrinsics.CameraMatrix.CX(cx)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: (float, int,), got {value_type}".format(
+                        value_type=type(cx)
+                    )
+                )
+
+            if isinstance(
+                cy,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._cy = _zivid.CameraIntrinsics.CameraMatrix.CY(cy)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: (float, int,), got {value_type}".format(
+                        value_type=type(cy)
+                    )
+                )
+
+            if isinstance(
+                fx,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._fx = _zivid.CameraIntrinsics.CameraMatrix.FX(fx)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: (float, int,), got {value_type}".format(
+                        value_type=type(fx)
+                    )
+                )
+
+            if isinstance(
+                fy,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._fy = _zivid.CameraIntrinsics.CameraMatrix.FY(fy)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: (float, int,), got {value_type}".format(
+                        value_type=type(fy)
+                    )
+                )
+
+        @property
+        def cx(self):
+            return self._cx.value
+
+        @property
+        def cy(self):
+            return self._cy.value
+
+        @property
+        def fx(self):
+            return self._fx.value
+
+        @property
+        def fy(self):
+            return self._fy.value
+
+        @cx.setter
+        def cx(self, value):
+            if isinstance(
+                value,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._cx = _zivid.CameraIntrinsics.CameraMatrix.CX(value)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: float or  int, got {value_type}".format(
+                        value_type=type(value)
+                    )
+                )
+
+        @cy.setter
+        def cy(self, value):
+            if isinstance(
+                value,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._cy = _zivid.CameraIntrinsics.CameraMatrix.CY(value)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: float or  int, got {value_type}".format(
+                        value_type=type(value)
+                    )
+                )
+
+        @fx.setter
+        def fx(self, value):
+            if isinstance(
+                value,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._fx = _zivid.CameraIntrinsics.CameraMatrix.FX(value)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: float or  int, got {value_type}".format(
+                        value_type=type(value)
+                    )
+                )
+
+        @fy.setter
+        def fy(self, value):
+            if isinstance(
+                value,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._fy = _zivid.CameraIntrinsics.CameraMatrix.FY(value)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: float or  int, got {value_type}".format(
+                        value_type=type(value)
+                    )
+                )
+
+        def __eq__(self, other):
+            if (
+                self._cx == other._cx
+                and self._cy == other._cy
+                and self._fx == other._fx
+                and self._fy == other._fy
+            ):
+                return True
+            return False
+
+        def __str__(self):
+            return str(_to_internal_camera_intrinsics_camera_matrix(self))
+
+    class Distortion:
+        def __init__(
+            self,
+            k1=_zivid.CameraIntrinsics.Distortion.K1().value,
+            k2=_zivid.CameraIntrinsics.Distortion.K2().value,
+            k3=_zivid.CameraIntrinsics.Distortion.K3().value,
+            p1=_zivid.CameraIntrinsics.Distortion.P1().value,
+            p2=_zivid.CameraIntrinsics.Distortion.P2().value,
+        ):
+
+            if isinstance(
+                k1,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._k1 = _zivid.CameraIntrinsics.Distortion.K1(k1)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: (float, int,), got {value_type}".format(
+                        value_type=type(k1)
+                    )
+                )
+
+            if isinstance(
+                k2,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._k2 = _zivid.CameraIntrinsics.Distortion.K2(k2)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: (float, int,), got {value_type}".format(
+                        value_type=type(k2)
+                    )
+                )
+
+            if isinstance(
+                k3,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._k3 = _zivid.CameraIntrinsics.Distortion.K3(k3)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: (float, int,), got {value_type}".format(
+                        value_type=type(k3)
+                    )
+                )
+
+            if isinstance(
+                p1,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._p1 = _zivid.CameraIntrinsics.Distortion.P1(p1)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: (float, int,), got {value_type}".format(
+                        value_type=type(p1)
+                    )
+                )
+
+            if isinstance(
+                p2,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._p2 = _zivid.CameraIntrinsics.Distortion.P2(p2)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: (float, int,), got {value_type}".format(
+                        value_type=type(p2)
+                    )
+                )
+
+        @property
+        def k1(self):
+            return self._k1.value
+
+        @property
+        def k2(self):
+            return self._k2.value
+
+        @property
+        def k3(self):
+            return self._k3.value
+
+        @property
+        def p1(self):
+            return self._p1.value
+
+        @property
+        def p2(self):
+            return self._p2.value
+
+        @k1.setter
+        def k1(self, value):
+            if isinstance(
+                value,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._k1 = _zivid.CameraIntrinsics.Distortion.K1(value)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: float or  int, got {value_type}".format(
+                        value_type=type(value)
+                    )
+                )
+
+        @k2.setter
+        def k2(self, value):
+            if isinstance(
+                value,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._k2 = _zivid.CameraIntrinsics.Distortion.K2(value)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: float or  int, got {value_type}".format(
+                        value_type=type(value)
+                    )
+                )
+
+        @k3.setter
+        def k3(self, value):
+            if isinstance(
+                value,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._k3 = _zivid.CameraIntrinsics.Distortion.K3(value)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: float or  int, got {value_type}".format(
+                        value_type=type(value)
+                    )
+                )
+
+        @p1.setter
+        def p1(self, value):
+            if isinstance(
+                value,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._p1 = _zivid.CameraIntrinsics.Distortion.P1(value)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: float or  int, got {value_type}".format(
+                        value_type=type(value)
+                    )
+                )
+
+        @p2.setter
+        def p2(self, value):
+            if isinstance(
+                value,
+                (
+                    float,
+                    int,
+                ),
+            ):
+                self._p2 = _zivid.CameraIntrinsics.Distortion.P2(value)
+            else:
+                raise TypeError(
+                    "Unsupported type, expected: float or  int, got {value_type}".format(
+                        value_type=type(value)
+                    )
+                )
+
+        def __eq__(self, other):
+            if (
+                self._k1 == other._k1
+                and self._k2 == other._k2
+                and self._k3 == other._k3
+                and self._p1 == other._p1
+                and self._p2 == other._p2
+            ):
+                return True
+            return False
+
+        def __str__(self):
+            return str(_to_internal_camera_intrinsics_distortion(self))
+
+    def __init__(
+        self,
+        camera_matrix=None,
+        distortion=None,
+    ):
+
+        if camera_matrix is None:
+            camera_matrix = self.CameraMatrix()
+        if not isinstance(camera_matrix, self.CameraMatrix):
+            raise TypeError(
+                "Unsupported type: {value}".format(value=type(camera_matrix))
+            )
+        self._camera_matrix = camera_matrix
+
+        if distortion is None:
+            distortion = self.Distortion()
+        if not isinstance(distortion, self.Distortion):
+            raise TypeError("Unsupported type: {value}".format(value=type(distortion)))
+        self._distortion = distortion
+
+    @property
+    def camera_matrix(self):
+        return self._camera_matrix
+
+    @property
+    def distortion(self):
+        return self._distortion
+
+    @camera_matrix.setter
+    def camera_matrix(self, value):
+        if not isinstance(value, self.CameraMatrix):
+            raise TypeError("Unsupported type {value}".format(value=type(value)))
+        self._camera_matrix = value
+
+    @distortion.setter
+    def distortion(self, value):
+        if not isinstance(value, self.Distortion):
+            raise TypeError("Unsupported type {value}".format(value=type(value)))
+        self._distortion = value
+
+    @classmethod
+    def load(cls, file_name):
+        return _to_camera_intrinsics(_zivid.CameraIntrinsics(str(file_name)))
+
+    def save(self, file_name):
+        _to_internal_camera_intrinsics(self).save(str(file_name))
+
+    def __eq__(self, other):
+        if (
+            self._camera_matrix == other._camera_matrix
+            and self._distortion == other._distortion
+        ):
+            return True
+        return False
+
+    def __str__(self):
+        return str(_to_internal_camera_intrinsics(self))
+
+
+def _to_camera_intrinsics_camera_matrix(internal_camera_matrix):
+    return CameraIntrinsics.CameraMatrix(
+        cx=internal_camera_matrix.cx.value,
+        cy=internal_camera_matrix.cy.value,
+        fx=internal_camera_matrix.fx.value,
+        fy=internal_camera_matrix.fy.value,
+    )
+
+
+def _to_camera_intrinsics_distortion(internal_distortion):
+    return CameraIntrinsics.Distortion(
+        k1=internal_distortion.k1.value,
+        k2=internal_distortion.k2.value,
+        k3=internal_distortion.k3.value,
+        p1=internal_distortion.p1.value,
+        p2=internal_distortion.p2.value,
+    )
+
+
+def _to_camera_intrinsics(internal_camera_intrinsics):
+    return CameraIntrinsics(
+        camera_matrix=_to_camera_intrinsics_camera_matrix(
+            internal_camera_intrinsics.camera_matrix
+        ),
+        distortion=_to_camera_intrinsics_distortion(
+            internal_camera_intrinsics.distortion
+        ),
+    )
+
+
+def _to_internal_camera_intrinsics_camera_matrix(camera_matrix):
+    internal_camera_matrix = _zivid.CameraIntrinsics.CameraMatrix()
+
+    internal_camera_matrix.cx = _zivid.CameraIntrinsics.CameraMatrix.CX(
+        camera_matrix.cx
+    )
+    internal_camera_matrix.cy = _zivid.CameraIntrinsics.CameraMatrix.CY(
+        camera_matrix.cy
+    )
+    internal_camera_matrix.fx = _zivid.CameraIntrinsics.CameraMatrix.FX(
+        camera_matrix.fx
+    )
+    internal_camera_matrix.fy = _zivid.CameraIntrinsics.CameraMatrix.FY(
+        camera_matrix.fy
+    )
+
+    return internal_camera_matrix
+
+
+def _to_internal_camera_intrinsics_distortion(distortion):
+    internal_distortion = _zivid.CameraIntrinsics.Distortion()
+
+    internal_distortion.k1 = _zivid.CameraIntrinsics.Distortion.K1(distortion.k1)
+    internal_distortion.k2 = _zivid.CameraIntrinsics.Distortion.K2(distortion.k2)
+    internal_distortion.k3 = _zivid.CameraIntrinsics.Distortion.K3(distortion.k3)
+    internal_distortion.p1 = _zivid.CameraIntrinsics.Distortion.P1(distortion.p1)
+    internal_distortion.p2 = _zivid.CameraIntrinsics.Distortion.P2(distortion.p2)
+
+    return internal_distortion
+
+
+def _to_internal_camera_intrinsics(camera_intrinsics):
+    internal_camera_intrinsics = _zivid.CameraIntrinsics()
+
+    internal_camera_intrinsics.camera_matrix = (
+        _to_internal_camera_intrinsics_camera_matrix(camera_intrinsics.camera_matrix)
+    )
+    internal_camera_intrinsics.distortion = _to_internal_camera_intrinsics_distortion(
+        camera_intrinsics.distortion
+    )
+    return internal_camera_intrinsics

--- a/modules/zivid/experimental/calibration.py
+++ b/modules/zivid/experimental/calibration.py
@@ -1,0 +1,38 @@
+"""Module for experimental calibration features. This API may change in the future."""
+
+import _zivid
+from zivid.camera_intrinsics import _to_camera_intrinsics
+
+
+def intrinsics(camera):
+    """Get intrinsic parameters of a given camera.
+
+    Args:
+        camera: A Camera instance
+
+    Returns:
+        A CameraIntrinsics instance
+    """
+    return _to_camera_intrinsics(
+        _zivid.calibration.intrinsics(
+            camera._Camera__impl  # pylint: disable=protected-access
+        )
+    )
+
+
+def estimate_intrinsics(frame):
+    """Estimate camera intrinsics for a given frame.
+
+    This function is for advanced use cases. Otherwise, use intrinsics(camera).
+
+    Args:
+        frame: A Frame instance
+
+    Returns:
+        A CameraIntrinsics instance
+    """
+    return _to_camera_intrinsics(
+        _zivid.calibration.estimate_intrinsics(
+            frame._Frame__impl  # pylint: disable=protected-access
+        )
+    )

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ def _main():
         author="Zivid AS",
         author_email="customersuccess@zivid.com",
         license="BSD 3-Clause",
-        packages=["zivid", "zivid._calibration", "_zivid"],
+        packages=["zivid", "zivid._calibration", "zivid.experimental", "_zivid"],
         package_dir={"": "modules"},
         install_requires=["numpy"],
         cmake_args=[

--- a/src/Calibration/Calibration.cpp
+++ b/src/Calibration/Calibration.cpp
@@ -2,12 +2,15 @@
 #include <Zivid/Calibration/HandEye.h>
 #include <Zivid/Calibration/MultiCamera.h>
 #include <Zivid/Calibration/Pose.h>
+#include <Zivid/Experimental/Calibration.h>
 #include <Zivid/PointCloud.h>
 
 #include <ZividPython/Calibration/Detector.h>
 #include <ZividPython/Calibration/HandEye.h>
 #include <ZividPython/Calibration/MultiCamera.h>
 #include <ZividPython/Calibration/Pose.h>
+#include <ZividPython/ReleasableCamera.h>
+#include <ZividPython/ReleasableFrame.h>
 #include <ZividPython/ReleasablePointCloud.h>
 #include <ZividPython/Wrappers.h>
 
@@ -36,6 +39,13 @@ namespace ZividPython::Calibration
                  })
             .def("calibrate_eye_in_hand", &Zivid::Calibration::calibrateEyeInHand)
             .def("calibrate_eye_to_hand", &Zivid::Calibration::calibrateEyeToHand)
-            .def("calibrate_multi_camera", &Zivid::Calibration::calibrateMultiCamera);
+            .def("calibrate_multi_camera", &Zivid::Calibration::calibrateMultiCamera)
+            .def("intrinsics",
+                 [](ReleasableCamera &releasableCamera) {
+                     return Zivid::Experimental::Calibration::intrinsics(releasableCamera.impl());
+                 })
+            .def("estimate_intrinsics", [](ReleasableFrame &releasableFrame) {
+                return Zivid::Experimental::Calibration::estimateIntrinsics(releasableFrame.impl());
+            });
     }
 } // namespace ZividPython::Calibration

--- a/test/calibration/test_intrinsics.py
+++ b/test/calibration/test_intrinsics.py
@@ -1,0 +1,31 @@
+def _check_camera_intrinsics(camera_intrinsics):
+    from zivid import CameraIntrinsics
+
+    assert isinstance(camera_intrinsics, CameraIntrinsics)
+    assert isinstance(camera_intrinsics.camera_matrix, CameraIntrinsics.CameraMatrix)
+    assert isinstance(camera_intrinsics.distortion, CameraIntrinsics.Distortion)
+
+    assert isinstance(camera_intrinsics.camera_matrix.fx, float)
+    assert isinstance(camera_intrinsics.camera_matrix.fy, float)
+    assert isinstance(camera_intrinsics.camera_matrix.cx, float)
+    assert isinstance(camera_intrinsics.camera_matrix.cy, float)
+
+    assert isinstance(camera_intrinsics.distortion.k1, float)
+    assert isinstance(camera_intrinsics.distortion.k2, float)
+    assert isinstance(camera_intrinsics.distortion.k3, float)
+    assert isinstance(camera_intrinsics.distortion.p1, float)
+    assert isinstance(camera_intrinsics.distortion.p2, float)
+
+
+def test_intrinsics(file_camera):
+    from zivid.experimental.calibration import intrinsics
+
+    camera_intrinsics = intrinsics(file_camera)
+    _check_camera_intrinsics(camera_intrinsics)
+
+
+def test_estimate_intrinsics(frame):
+    from zivid.experimental.calibration import estimate_intrinsics
+
+    camera_intrinsics = estimate_intrinsics(frame)
+    _check_camera_intrinsics(camera_intrinsics)


### PR DESCRIPTION
This commit expands the Python wrapper to give access to the
experimental camera intrinsics API. This entails two new functions:
```
from zivid.experimental.calibration import intrinsics
from zivid.experimental.calibration import estimate_intrinsics
```

As part of this the CameraIntrinsics data-model also needs to be
wrapped. Since this data-model (as opposed to the above mentioned
functions) is not technically experimental in the C++ API, it is not
added as experimental here either.

This resolves Issue #42