### PR TITLE
Upgrade to PyBind11 2.9.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include(${CMAKE_BINARY_DIR}/conan.cmake)
 conan_cmake_run(
     REQUIRES
         eigen/3.3.9
-        pybind11/2.6.1
+        pybind11/2.9.1
     CMAKE_TARGETS
     BASIC_SETUP)
 


### PR DESCRIPTION
* This adds supports for mapping std::NestedException to nested equivalent Python Exceptions. I implemented it in PyBind11 and it was mentioned that in the issue that it would be useful for this repo.