### PR TITLE
Add in-field correction/verification API

### DIFF
--- a/modules/_zivid/__init__.py
+++ b/modules/_zivid/__init__.py
@@ -57,6 +57,7 @@ try:
         Frame2D,
         ImageRGBA,
         CameraInfo,
+        infield_correction,
     )
 except ImportError as ex:
 

--- a/modules/zivid/experimental/calibration.py
+++ b/modules/zivid/experimental/calibration.py
@@ -1,6 +1,7 @@
 """Module for experimental calibration features. This API may change in the future."""
 
 import _zivid
+from zivid.calibration import DetectionResult
 from zivid.camera_intrinsics import _to_camera_intrinsics
 
 
@@ -36,3 +37,366 @@ def estimate_intrinsics(frame):
             frame._Frame__impl  # pylint: disable=protected-access
         )
     )
+
+
+def detect_feature_points(camera):
+    """Detect feature points from a calibration object.
+
+    Using this version of the detectFeaturePoints function is necessary to
+    ensure that the data quality is sufficient for use in in-field verification
+    and correction.
+
+    The functionality is to be exclusively used in combination with Zivid
+    verified checkerboards.
+
+    Args:
+        camera: A Camera that is pointing at a calibration checkerboard.
+
+    Returns:
+        A DetectionResult instance.
+    """
+    return DetectionResult(
+        _zivid.infield_correction.detect_feature_points_infield(
+            camera._Camera__impl  # pylint: disable=protected-access
+        )
+    )
+
+
+def verify_camera(infield_correction_input):
+    """Verify the current camera trueness based on a single measurement.
+
+    The purpose of this function is to allow quick assessment of the quality of
+    the in-field correction on a camera (or the need for one if none exists
+    already). This function will throw an exception if any of the provided
+    InfieldCorrectionInput have valid()==False.
+
+    The return value of this function will give an indication of the dimension
+    trueness at the location where the input data was captured. If the returned
+    assessment indicates a trueness error that is above threshold for your
+    application, consider using compute_camera_correction in order to get an
+    updated correction for the camera.
+
+    Args:
+        infield_correction_input: An InfieldCorrectionInput instance.
+
+    Returns:
+        A CameraVerification instance.
+    """
+    return CameraVerification(
+        _zivid.infield_correction.verify_camera(
+            infield_correction_input._InfieldCorrectionInput__impl  # pylint: disable=protected-access
+        )
+    )
+
+
+def compute_camera_correction(dataset):
+    """Calculate new in-field camera correction.
+
+    The purpose of this function is to calculate a new in-field correction for a
+    camera based on a series of calibration object captures taken at varying
+    distances. This function will throw an exception if any of the provided
+    InfieldCorrectionInput have valid()==False.
+
+    The quantity and range of data is up to the user, but generally a larger
+    dataset will yield a more accurate and reliable correction. If all
+    measurements were taken at approximately the same distance, the resulting
+    correction will mainly be valid at those distances. If several measurements
+    were taken at significantly different distances, the resulting correction
+    will likely be more suitable for extrapolation to distances beyond where the
+    dataset was collected.
+
+    The result of this process is a CameraCorrection object, which will contain
+    information regarding the proposed working range and the accuracy that can
+    be expected within the working range, if the correction is written to the
+    camera. The correction may be written to the camera using
+    writeCameraCorrection.
+
+    This function will throw an exception if the input data is extremely
+    inconsistent/noisy.
+
+    Args:
+        dataset: A list of InfieldCorrectionInput instances.
+
+    Returns:
+        A CameraCorrection instance.
+    """
+    return CameraCorrection(
+        _zivid.infield_correction.compute_camera_correction(
+            [
+                infield_correction_input._InfieldCorrectionInput__impl  # pylint: disable=protected-access
+                for infield_correction_input in dataset
+            ]
+        )
+    )
+
+
+def write_camera_correction(camera, camera_correction):
+    """Write the in-field correction on a camera.
+
+    After calling this function, the given correction will automatically be used
+    any time the capture function is called on this camera. The correction will
+    be persisted on the camera even though the camera is power-cycled or
+    connected to a different PC.
+
+    Beware that calling this will overwrite any existing correction present on
+    the camera.
+
+    Args:
+        camera: The Camera to write the correction to.
+        camera_correction: The CameraCorrection instance to write to the camera.
+    """
+    _zivid.infield_correction.write_camera_correction(
+        camera._Camera__impl,  # pylint: disable=protected-access
+        camera_correction._CameraCorrection__impl,  # pylint: disable=protected-access
+    )
+
+
+def reset_camera_correction(camera):
+    """Reset the in-field correction on a camera to factory settings.
+
+    Args:
+        camera: The Camera to reset.
+    """
+    _zivid.infield_correction.reset_camera_correction(
+        camera._Camera__impl  # pylint: disable=protected-access
+    )
+
+
+def has_camera_correction(camera):
+    """Check if the camera has an in-field correction written to it.
+
+    This is false if write_camera_correction has never been called using this
+    camera. It will also be false after calling reset_camera_correction.
+
+    Args:
+        camera: The Camera to check.
+
+    Returns:
+        Boolean indicating whether or not the camera has an in-field correction.
+    """
+    return _zivid.infield_correction.has_camera_correction(
+        camera._Camera__impl  # pylint: disable=protected-access
+    )
+
+
+def camera_correction_timestamp(camera):
+    """Get the time at which the camera's in-field correction was created.
+
+    Args:
+        camera: The Camera to check.
+
+    Returns:
+        A timestamp indicating when the correction was created.
+    """
+
+    return _zivid.infield_correction.camera_correction_timestamp(
+        camera._Camera__impl  # pylint: disable=protected-access
+    )
+
+
+class InfieldCorrectionInput:
+    """Container for input-data needed by in-field verification and correction functions."""
+
+    def __init__(self, detection_result):
+        """Construct an InfieldCorrectionInput instance.
+
+        Input data should be captured by calling the version of detect_feature_points that
+        takes a Camera argument.
+
+        Args:
+            detection_result: A DetectionResult instance
+
+        Raises:
+            TypeError: If one of the input arguments are of the wrong type
+        """
+        if not isinstance(detection_result, DetectionResult):
+            raise TypeError(
+                "Unsupported type for argument detection_result. Expected zivid.calibration.DetectionResult but got {}".format(
+                    type(detection_result)
+                )
+            )
+        self.__impl = _zivid.infield_correction.InfieldCorrectionInput(
+            detection_result._DetectionResult__impl,  # pylint: disable=protected-access
+        )
+
+    def detection_result(self):
+        """Get the contained DetectionResult.
+
+        Returns:
+            A DetectionResult instance
+        """
+        return DetectionResult(self.__impl.detection_result())
+
+    def valid(self):
+        """Check if this object is valid for use with in-field correction.
+
+        Returns:
+            True if InfieldCorrectionInput is valid
+        """
+        return self.__impl.valid()
+
+    def status_description(self):
+        """Get a string describing the status of this input object.
+
+        Mostly used to figure out why valid() is False.
+
+        Returns:
+            A human-readable string describing the status.
+        """
+        return self.__impl.status_description()
+
+    def __bool__(self):
+        return self.valid()
+
+    def __str__(self):
+        return str(self.__impl)
+
+
+class CameraVerification:
+    """An assessment of the current dimension trueness of a camera at a specific location."""
+
+    def __init__(self, impl):
+        """Initialize CameraVerification wrapper.
+
+        This constructor is only used internally, and should not be called by the end-user.
+
+        Args:
+            impl:   Reference to internal/back-end instance.
+
+        Raises:
+            TypeError: If argument does not match the expected internal class.
+        """
+        if not isinstance(impl, _zivid.infield_correction.CameraVerification):
+            raise TypeError(
+                "Unsupported type for argument impl. Got {}, expected {}".format(
+                    type(impl), type(_zivid.infield_correction.CameraVerification)
+                )
+            )
+        self.__impl = impl
+
+    def local_dimension_trueness(self):
+        """Get the estimated local dimension trueness.
+
+        The dimension trueness represents the relative deviation between the
+        measured size of the calibration object and the true size of the
+        calibration object, including the effects of any in-field correction
+        stored on the camera at the time of capture. Note that this estimate is
+        local, i.e. only valid for the region of space very close to the
+        calibration object.
+
+        The returned value is a fraction (relative trueness error). Multiply by
+        100 to get trueness in percent.
+
+        Returns:
+            Estimated local dimension trueness.
+        """
+        return self.__impl.local_dimension_trueness()
+
+    def position(self):
+        """Get the location at which the measurement was made.
+
+        Returns:
+            Location (XYZ) in the camera reference frame.
+        """
+        return self.__impl.position()
+
+    def __str__(self):
+        return str(self.__impl)
+
+
+class AccuracyEstimate:
+    """A dimension accuracy estimate for a specific working volume."""
+
+    def __init__(self, impl):
+        """Initialize AccuracyEstimate wrapper.
+
+        This constructor is only used internally, and should not be called by the end-user.
+
+        Args:
+            impl:   Reference to internal/back-end instance.
+
+        Raises:
+            TypeError: If argument does not match the expected internal class.
+        """
+        if not isinstance(impl, _zivid.infield_correction.AccuracyEstimate):
+            raise TypeError(
+                "Unsupported type for argument impl. Got {}, expected {}".format(
+                    type(impl), type(_zivid.infield_correction.AccuracyEstimate)
+                )
+            )
+        self.__impl = impl
+
+    def dimension_accuracy(self):
+        """Get the estimated dimension accuracy obtained if the correction is applied.
+
+        This number represents a 1-sigma (68% confidence) upper bound for
+        dimension trueness error in the working volume (z=zMin() to z=zMax(),
+        across the entire field of view). In other words, it represents the
+        expected distribution of local dimension trueness measurements (see
+        CameraVerification) that can be expected if measuring throughout the
+        working volume.
+
+        The returned value is a fraction (relative trueness error). Multiply by
+        100 to get trueness in percent.
+
+        Note that the accuracy close to where the original data was captured is
+        likely much better than what is implied by this number. This number is
+        rather an accuracy estimate for the entire extrapolated working volume.
+
+        Returns:
+            A 1-sigma (68% confidence) upper bound for trueness error in the working volume.
+        """
+        return self.__impl.dimension_accuracy()
+
+    def z_min(self):
+        """Get the range of validity of the accuracy estimate (lower end).
+
+        Returns:
+            Minimum z-value of working volume in millimeters.
+        """
+        return self.__impl.z_min()
+
+    def z_max(self):
+        """Get the range of validity of the accuracy estimate (upper end).
+
+        Returns:
+            Maximum z-value of working volume in millimeters.
+        """
+        return self.__impl.z_max()
+
+    def __str__(self):
+        return str(self.__impl)
+
+
+class CameraCorrection:
+    """An in-field correction that may be written to a camera."""
+
+    def __init__(self, impl):
+        """Initialize CameraCorrection wrapper.
+
+        This constructor is only used internally, and should not be called by the end-user.
+
+        Args:
+            impl:   Reference to internal/back-end instance.
+
+        Raises:
+            TypeError: If argument does not match the expected internal class.
+        """
+        if not isinstance(impl, _zivid.infield_correction.CameraCorrection):
+            raise TypeError(
+                "Unsupported type for argument impl. Got {}, expected {}".format(
+                    type(impl), type(_zivid.infield_correction.CameraCorrection)
+                )
+            )
+        self.__impl = impl
+
+    def accuracy_estimate(self):
+        """Get an estimate for expected dimension accuracy if the correction is applied to the camera.
+
+        Returns:
+            An AccuracyEstimate instance.
+        """
+        return AccuracyEstimate(self.__impl.accuracy_estimate())
+
+    def __str__(self):
+        return str(self.__impl)

--- a/samples/sample_infield_correction.py
+++ b/samples/sample_infield_correction.py
@@ -1,0 +1,49 @@
+"""Sample demonstrating in-field correction (experimental)."""
+import zivid
+
+from zivid.experimental.calibration import (
+    detect_feature_points,
+    InfieldCorrectionInput,
+    compute_camera_correction,
+    write_camera_correction,
+)
+
+
+def _main():
+    app = zivid.Application()
+    camera = app.connect_camera()
+
+    infield_inputs = []
+
+    try:
+        while True:
+            detection_result = detect_feature_points(camera)
+            infield_input = InfieldCorrectionInput(detection_result)
+            if infield_input.valid():
+                print("Measurement OK. Appending to dataset.")
+                infield_inputs.append(infield_input)
+            else:
+                print(
+                    f"Warning: Measurement invalid [{infield_input.status_description()}]. Please try again."
+                )
+
+            input(
+                "Hit [Enter] to continue, or [Ctrl+C] to end capture loop and calculate correction."
+            )
+    except KeyboardInterrupt:
+        print("\nCapture loop ended.")
+
+    correction = compute_camera_correction(infield_inputs)
+    print("Successfully calculated camera correction")
+    print(correction.accuracy_estimate())
+    print(correction.accuracy_estimate().dimension_accuracy())
+
+    answer = input("Write correction to camera? (y/n)")
+    if answer == "y":
+        print("Writing correction to camera")
+        write_camera_correction(camera, correction)
+    print("Finished")
+
+
+if __name__ == "__main__":
+    _main()

--- a/samples/sample_infield_verification.py
+++ b/samples/sample_infield_verification.py
@@ -1,0 +1,40 @@
+"""Sample demonstrating in-field verification (experimental)."""
+import zivid
+
+from zivid.experimental.calibration import (
+    detect_feature_points,
+    InfieldCorrectionInput,
+    verify_camera,
+    has_camera_correction,
+    camera_correction_timestamp,
+)
+
+
+def _main():
+    app = zivid.Application()
+    camera = app.connect_camera()
+
+    print("Checking current correction status")
+    if has_camera_correction(camera):
+        timestamp = camera_correction_timestamp(camera)
+        print(
+            f"Camera currently has a correction. Timestamp: {timestamp.strftime(r'%Y-%m-%d %H:%M:%S')}"
+        )
+
+    print("Detecting feature points for verification...")
+    detection_result = detect_feature_points(camera)
+    print(f"Feature point detection: {detection_result}")
+    infield_input = InfieldCorrectionInput(detection_result)
+    print(f"In-field correction input: {infield_input}")
+    if not infield_input.valid():
+        raise RuntimeError(
+            f"Capture not appropriate for in-field correction/verification. Reason: {infield_input.status_description()}"
+        )
+    camera_verification = verify_camera(infield_input)
+    print(
+        f"Local dimension trueness: {camera_verification.local_dimension_trueness()*100:.3f}%"
+    )
+
+
+if __name__ == "__main__":
+    _main()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     CaptureAssistant.cpp
     DataModel.cpp
     Firmware.cpp
+    InfieldCorrection/InfieldCorrection.cpp
     NodeType.cpp
     ReleasableArray2D.cpp
     ReleasableCamera.cpp

--- a/src/InfieldCorrection/InfieldCorrection.cpp
+++ b/src/InfieldCorrection/InfieldCorrection.cpp
@@ -1,0 +1,73 @@
+#include <Zivid/Experimental/Calibration/InfieldCorrection.h>
+
+#include <ZividPython/InfieldCorrection/InfieldCorrection.h>
+#include <ZividPython/Matrix.h>
+#include <ZividPython/ReleasableCamera.h>
+
+#include <pybind11/pybind11.h>
+
+#include <vector>
+
+namespace py = pybind11;
+
+namespace ZividPython::InfieldCorrection
+{
+    void wrapAsSubmodule(pybind11::module &dest)
+    {
+        using namespace Zivid::Experimental::Calibration;
+
+        ZIVID_PYTHON_WRAP_CLASS(dest, InfieldCorrectionInput);
+        ZIVID_PYTHON_WRAP_CLASS(dest, CameraVerification);
+        ZIVID_PYTHON_WRAP_CLASS(dest, AccuracyEstimate);
+        ZIVID_PYTHON_WRAP_CLASS(dest, CameraCorrection);
+
+        dest.def("detect_feature_points_infield",
+                 [](ReleasableCamera &releasableCamera) { return detectFeaturePoints(releasableCamera.impl()); })
+            .def("verify_camera", &verifyCamera)
+            .def("compute_camera_correction", &computeCameraCorrection)
+            .def("write_camera_correction",
+                 [](ReleasableCamera &releasableCamera, CameraCorrection cameraCorrection) {
+                     writeCameraCorrection(releasableCamera.impl(), cameraCorrection);
+                 })
+            .def("reset_camera_correction",
+                 [](ReleasableCamera &releasableCamera) { resetCameraCorrection(releasableCamera.impl()); })
+            .def("has_camera_correction",
+                 [](ReleasableCamera &releasableCamera) { return hasCameraCorrection(releasableCamera.impl()); })
+            .def("camera_correction_timestamp",
+                 [](ReleasableCamera &releasableCamera) { return cameraCorrectionTimestamp(releasableCamera.impl()); });
+    }
+} // namespace ZividPython::InfieldCorrection
+
+namespace ZividPython
+{
+    using namespace Zivid::Experimental::Calibration;
+
+    void wrapClass(pybind11::class_<InfieldCorrectionInput> pyClass)
+    {
+        pyClass.def(py::init<Zivid::Calibration::DetectionResult>())
+            .def("valid", &InfieldCorrectionInput::valid)
+            .def("detection_result", &InfieldCorrectionInput::detectionResult)
+            .def("status_description", &InfieldCorrectionInput::statusDescription);
+    }
+
+    void wrapClass(pybind11::class_<CameraVerification> pyClass)
+    {
+        pyClass.def("local_dimension_trueness", &CameraVerification::localDimensionTrueness)
+            .def("position", [](const CameraVerification &cameraVerification) {
+                return Conversion::toPyVector(cameraVerification.position());
+            });
+    }
+
+    void wrapClass(pybind11::class_<AccuracyEstimate> pyClass)
+    {
+        pyClass.def("dimension_accuracy", &AccuracyEstimate::dimensionAccuracy)
+            .def("z_min", &AccuracyEstimate::zMin)
+            .def("z_max", &AccuracyEstimate::zMax);
+    }
+
+    void wrapClass(pybind11::class_<CameraCorrection> pyClass)
+    {
+        pyClass.def("accuracy_estimate", &CameraCorrection::accuracyEstimate);
+    }
+
+} // namespace ZividPython

--- a/src/Wrapper.cpp
+++ b/src/Wrapper.cpp
@@ -8,6 +8,7 @@
 #include <ZividPython/CaptureAssistant.h>
 #include <ZividPython/DataModel.h>
 #include <ZividPython/Firmware.h>
+#include <ZividPython/InfieldCorrection/InfieldCorrection.h>
 #include <ZividPython/ReleasableArray2D.h>
 #include <ZividPython/ReleasableCamera.h>
 #include <ZividPython/ReleasableFrame.h>
@@ -54,4 +55,5 @@ ZIVID_PYTHON_MODULE // NOLINT
     ZIVID_PYTHON_WRAP_NAMESPACE_AS_SUBMODULE(module, Version);
     ZIVID_PYTHON_WRAP_NAMESPACE_AS_SUBMODULE(module, Calibration);
     ZIVID_PYTHON_WRAP_NAMESPACE_AS_SUBMODULE(module, CaptureAssistant);
+    ZIVID_PYTHON_WRAP_NAMESPACE_AS_SUBMODULE(module, InfieldCorrection);
 }

--- a/src/include/ZividPython/InfieldCorrection/InfieldCorrection.h
+++ b/src/include/ZividPython/InfieldCorrection/InfieldCorrection.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Zivid/Experimental/Calibration/InfieldCorrection.h>
+#include <ZividPython/Wrappers.h>
+
+namespace ZividPython::InfieldCorrection
+{
+    void wrapAsSubmodule(pybind11::module &dest);
+} // namespace ZividPython::InfieldCorrection
+
+namespace ZividPython
+{
+    void wrapClass(pybind11::class_<Zivid::Experimental::Calibration::InfieldCorrectionInput> pyClass);
+    void wrapClass(pybind11::class_<Zivid::Experimental::Calibration::CameraVerification> pyClass);
+    void wrapClass(pybind11::class_<Zivid::Experimental::Calibration::AccuracyEstimate> pyClass);
+    void wrapClass(pybind11::class_<Zivid::Experimental::Calibration::CameraCorrection> pyClass);
+} // namespace ZividPython


### PR DESCRIPTION
This commit extends zivid-python to wrap the existing experimental C++
"in-field correction/verification" API:
<https://support.zivid.com/latest/academy/camera/infield-correction.html>

See the two new samples for a demonstration of usage:
`samples/sample_infield_verification.py`
`samples/sample_infield_correction.py`