### PR TITLE
Re-enable unit-testing on fedora35 and archlinux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: ["ubuntu:18.04", "ubuntu:20.04", "fedora:30", "fedora:33", "fedora:34"]
+        os:
+          - ubuntu:18.04
+          - ubuntu:20.04
+          - fedora:30
+          - fedora:33
+          - fedora:34
+          - fedora:35
+          - archlinux/archlinux:base
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ Please visit [Zivid Knowledge Base][zivid-knowledge-base-url] for general inform
 | Fedora 30        | 3.7                      | 2.7.0             |
 | Fedora 33        | 3.9                      | 2.7.0             |
 | Fedora 34        | 3.9                      | 2.7.0             |
+| Fedora 35        | 3.10                     | 2.7.0             |
 | Windows 10       | 3.6, 3.7, 3.8, 3.9, 3.10 | 2.7.0             |
+| Arch Linux       | latest                   | 2.7.0             |
 
 [header-image]: https://www.zivid.com/hubfs/softwarefiles/images/zivid-generic-github-header.png
 [ci-badge]: https://img.shields.io/github/workflow/status/zivid/zivid-python/Main%20CI%20workflow/master

--- a/continuous-integration/linux/platform-dependent/fedora-35/setup.sh
+++ b/continuous-integration/linux/platform-dependent/fedora-35/setup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(realpath $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) )"
+
+dnf --assumeyes install \
+    bsdtar \
+    clinfo \
+    g++ \
+    libatomic \
+    python3-devel \
+    python3-pip \
+    wget \
+    || exit $?
+
+alternatives --install /usr/bin/python python /usr/bin/python3 0 || exit $?
+alternatives --install /usr/bin/pip pip /usr/bin/pip3 0 || exit $?
+
+source $(realpath $SCRIPT_DIR/../common.sh) || exit $?
+# Install OpenCL CPU runtime driver prerequisites
+dnf --assumeyes install \
+    numactl-libs \
+    redhat-lsb-core \
+    || exit $?
+install_opencl_cpu_runtime || exit $?
+
+function install_www_deb {
+    TMP_DIR=$(mktemp --tmpdir --directory zivid-python-install-www-deb-XXXX) || exit $?
+    pushd $TMP_DIR || exit $?
+    wget -nv "$@" || exit $?
+    ar x ./*deb || exit $?
+    bsdtar -xf data.tar.*z -C / || exit $?
+    ldconfig || exit $?
+    popd || exit $?
+    rm -r $TMP_DIR || exit $?
+}
+
+install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.7.0+e31dcbe2-1/u20/zivid-telicam-driver_3.0.1.1-3_amd64.deb || exit $?
+install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.7.0+e31dcbe2-1/u20/zivid_2.7.0+e31dcbe2-1_amd64.deb || exit $?


### PR DESCRIPTION
Unit-testing on fedora35 and archlinux was previously removed due to a
bug. The bug has been fixed, so we can re-enable it.

Fixes #161