### PR TITLE
Fix archlinux setup

### DIFF
--- a/continuous-integration/linux/setup.sh
+++ b/continuous-integration/linux/setup.sh
@@ -15,7 +15,7 @@ fi
 source /etc/os-release || exit $?
 
 osId=$ID
-if [[ $VERSION_ID ]]; then
+if [[ $ID != "arch" ]]; then
     osId=$osId-$VERSION_ID
 fi
 


### PR DESCRIPTION
A recent change in Archlinux has made it so that `VERSION_ID` in
`/etc/os-release` has `VERSION_ID=TEMPLATE_VERSION_ID` instead of not
defining `VERSION_ID`. This caused `setup.sh` to compute the wrong
directory name of the arch setup scrip. This commit fixes this issue.