### PR TITLE
Expose Zivid::Matrix4x4 to the Python bindings 

### DIFF
--- a/modules/_zivid/__init__.py
+++ b/modules/_zivid/__init__.py
@@ -58,6 +58,7 @@ try:
         ImageRGBA,
         CameraInfo,
         infield_correction,
+        Matrix4x4,
     )
 except ImportError as ex:
 

--- a/modules/zivid/__init__.py
+++ b/modules/zivid/__init__.py
@@ -1,6 +1,5 @@
 """This file imports all non protected classes, modules and packages from the current level."""
 
-
 import zivid._version
 
 __version__ = zivid._version.get_version(__name__)  # pylint: disable=protected-access
@@ -22,3 +21,4 @@ from zivid.settings import Settings
 from zivid.settings_2d import Settings2D
 from zivid.camera_info import CameraInfo
 from zivid.camera_intrinsics import CameraIntrinsics
+from zivid.matrix4x4 import Matrix4x4

--- a/modules/zivid/matrix4x4.py
+++ b/modules/zivid/matrix4x4.py
@@ -1,0 +1,89 @@
+"""Contains Matrix4x4 class."""
+import pathlib
+import _zivid
+
+
+class Matrix4x4(_zivid.Matrix4x4):
+    """Matrix of size 4x4 containing 32-bit floats."""
+
+    def __init__(self, arg=None):
+        """
+        Overloaded constructor.
+
+        Does different kinds of initializations depending on the argument:
+
+        * None or no arguments -> Zero initializes all values.
+        * 1 dimensional List or numpy.ndarray of 16 floats -> Map 1D array of 16 values into this 2D array of 4x4.
+        * 2 dimensional List or numpy.ndarray of 4x4 floats -> Copy 2D array of size 4x4.
+        * str or pathlib.Path -> Load the matrix from a file.
+
+        Args:
+            arg: Any of the above-mentioned.
+        """
+        if arg is None:
+            super().__init__()
+        elif isinstance(arg, pathlib.Path):
+            super().__init__(str(arg))
+        else:
+            super().__init__(arg)
+
+    def inverse(self):
+        """
+        Return the inverse of this matrix.
+
+        An exception is thrown if the matrix is not invertible.
+
+        Returns:
+            A new matrix, holding the inverse
+        """
+        return Matrix4x4(super().inverse())
+
+    def load(self, file_path):
+        """
+        Load the matrix from the given file.
+
+        Args:
+            file_path: path for the file to load the matrix from.
+        """
+        super().load(str(file_path))
+
+    def save(self, file_path):
+        """
+        Save the matrix to the given file.
+
+        Args:
+            file_path: path for the new file to save the matrix in.
+        """
+        super().save(str(file_path))
+
+    def __getitem__(self, indexes):
+        """
+        Access specified element with bounds checking.
+
+        Args:
+            indexes: a tuple of 2 integers as the indexes.
+
+        Returns:
+            The accessed item.
+        """
+        return super()._getitem(indexes)
+
+    def __iter__(self):
+        """
+        Return an iterator to iterate all 16 elements as if this is a 1D array.
+
+        Returns:
+            the iterator.
+        """
+        iterator = super().__iter__()
+        return iterator
+
+    def __setitem__(self, indexes, value):
+        """
+        Set specified element with bounds checking.
+
+        Args:
+            indexes: a tuple of 2 integers as the indexes.
+            value: value to set the specific item to.
+        """
+        super()._setitem(indexes, value)

--- a/samples/sample_calibrate_eye_to_hand.py
+++ b/samples/sample_calibrate_eye_to_hand.py
@@ -1,5 +1,7 @@
 """Hand-eye calibration sample."""
+from pathlib import Path
 import datetime
+import tempfile
 
 import numpy as np
 import zivid
@@ -74,6 +76,14 @@ def _main():
         print("Result:\n{}".format(calibration_result))
     else:
         print("FAILED")
+
+    print("Getting calibration result transformation matrix")
+    transformed_numpy_matrix = calibration_result.transform()
+
+    print("Saving calibration result transformation matrix")
+    with tempfile.TemporaryDirectory() as tempdir:
+        file_path = Path(tempdir) / "hand_eye.yml"
+        zivid.Matrix4x4(transformed_numpy_matrix).save(file_path)
 
 
 if __name__ == "__main__":

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
     SingletonApplication.cpp
     Version.cpp
     Wrapper.cpp
+    Matrix4x4.cpp
 )
 
 configure_file("Wrapper.h.in" "${CMAKE_CURRENT_BINARY_DIR}/include/ZividPython/Wrapper.h" @ONLY)

--- a/src/Matrix4x4.cpp
+++ b/src/Matrix4x4.cpp
@@ -1,0 +1,84 @@
+#include "ZividPython/Matrix4x4.h"
+
+#include <Zivid/Version.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <tuple>
+
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+using Zivid::Matrix4x4;
+
+namespace
+{
+    // Maps negative indexes to size + index, and throws if index is out of range
+    constexpr std::size_t mapIndex(const std::int64_t index, const std::size_t size)
+    {
+        const auto mappedIndex = (index < 0) ? static_cast<std::size_t>(size + index) : static_cast<std::size_t>(index);
+        if(mappedIndex >= size)
+        {
+            throw std::out_of_range("Matrix index " + std::to_string(index) + " out of range");
+        }
+        return mappedIndex;
+    }
+
+    Matrix4x4 createMatrixFrom4x4Array(
+        const std::array<std::array<Matrix4x4::ValueType, Matrix4x4::cols>, Matrix4x4::rows> &arr)
+    {
+        Matrix4x4 matrix;
+        auto iter = matrix.begin();
+        for(size_t row = 0; row < Matrix4x4::rows; ++row)
+        {
+            iter = std::copy_n(arr[row].data(), Matrix4x4::cols, iter);
+        }
+        return matrix;
+    }
+
+    auto getItem(const Matrix4x4 &matrix, const std::tuple<int64_t, int64_t> indexes)
+    {
+        const auto [row, col] = indexes;
+        return matrix(mapIndex(row, Matrix4x4::rows), mapIndex(col, Matrix4x4::cols));
+    }
+
+    void setItem(Matrix4x4 &matrix, const std::tuple<int64_t, int64_t> indexes, const Matrix4x4::ValueType value)
+    {
+        const auto [row, col] = indexes;
+        matrix(mapIndex(row, Matrix4x4::rows), mapIndex(col, Matrix4x4::cols)) = value;
+    }
+
+    auto bufferInfo(Matrix4x4 &matrix)
+    {
+        return py::buffer_info{ matrix.data(),
+                                sizeof(Matrix4x4::ValueType),
+                                py::format_descriptor<Matrix4x4::ValueType>::format(),
+                                2,
+                                { Matrix4x4::rows, Matrix4x4::cols },
+                                { sizeof(Matrix4x4::ValueType) * Matrix4x4::cols, sizeof(Matrix4x4::ValueType) } };
+    }
+} // namespace
+
+void ZividPython::wrapClass(py::class_<Zivid::Matrix4x4> pyClass)
+{
+    pyClass.doc() = "Matrix of size 4x4 containing 32 bit floats";
+    pyClass.def(py::init(), "Zero initializes all values")
+        .def(py::init<const std::array<Matrix4x4::ValueType, Matrix4x4::cols * Matrix4x4::rows> &>())
+        .def(py::init<const Matrix4x4 &>())
+        .def(py::init(&createMatrixFrom4x4Array))
+        .def(py::init<const std::string &>())
+        .def("save", &Matrix4x4::save)
+        .def("load", &Matrix4x4::load)
+        .def("_getitem", &getItem)
+        .def("_setitem", &setItem)
+        .def(
+            "__iter__",
+            [](const Matrix4x4 &matrix) { return py::make_iterator(matrix.cbegin(), matrix.cend()); },
+            py::keep_alive<0, 1>{})
+        .def_property_readonly_static("rows", [](const py::object & /*self*/) { return Matrix4x4::rows; })
+        .def_property_readonly_static("cols", [](const py::object & /*self*/) { return Matrix4x4::cols; })
+        .def("inverse", &Matrix4x4::inverse<Matrix4x4::ValueType>)
+        .def_buffer(&bufferInfo);
+}

--- a/src/Wrapper.cpp
+++ b/src/Wrapper.cpp
@@ -4,11 +4,11 @@
 #include <ZividPython/Wrappers.h>
 
 #include <ZividPython/Calibration/Calibration.h>
-#include <ZividPython/Calibration/Pose.h>
 #include <ZividPython/CaptureAssistant.h>
 #include <ZividPython/DataModel.h>
 #include <ZividPython/Firmware.h>
 #include <ZividPython/InfieldCorrection/InfieldCorrection.h>
+#include <ZividPython/Matrix4x4.h>
 #include <ZividPython/ReleasableArray2D.h>
 #include <ZividPython/ReleasableCamera.h>
 #include <ZividPython/ReleasableFrame.h>
@@ -39,6 +39,8 @@ ZIVID_PYTHON_MODULE // NOLINT
     ZIVID_PYTHON_WRAP_CLASS_AS_RELEASABLE(module, Camera);
     ZIVID_PYTHON_WRAP_CLASS_AS_RELEASABLE(module, Frame);
     ZIVID_PYTHON_WRAP_CLASS_AS_RELEASABLE(module, Frame2D);
+
+    ZIVID_PYTHON_WRAP_CLASS_BUFFER(module, Matrix4x4);
 
     ZIVID_PYTHON_WRAP_CLASS_BUFFER_AS_RELEASABLE(module, ImageRGBA);
     ZIVID_PYTHON_WRAP_CLASS_BUFFER_AS_RELEASABLE(module, PointCloud);

--- a/src/include/ZividPython/Matrix4x4.h
+++ b/src/include/ZividPython/Matrix4x4.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <Zivid/Matrix.h>
+
+#include <pybind11/pybind11.h>
+
+namespace ZividPython
+{
+    void wrapClass(pybind11::class_<Zivid::Matrix4x4> pyClass);
+}

--- a/src/include/ZividPython/Wrappers.h
+++ b/src/include/ZividPython/Wrappers.h
@@ -114,11 +114,14 @@ namespace ZividPython
     }
 } // namespace ZividPython
 
-#define ZIVID_PYTHON_WRAP_CLASS(dest, name)                                                                            \
+#define ZIVID_PYTHON_WRAP_CLASS(dest, name, ...)                                                                       \
     ZividPython::wrapClass<name, ZividPython::WrapType::normal>(dest,                                                  \
                                                                 static_cast<void (*)(pybind11::class_<name>)>(         \
                                                                     ZividPython::wrapClass),                           \
-                                                                #name)
+                                                                #name,                                                 \
+                                                                ##__VA_ARGS__)
+
+#define ZIVID_PYTHON_WRAP_CLASS_BUFFER(dest, name) ZIVID_PYTHON_WRAP_CLASS(dest, name, pybind11::buffer_protocol{})
 
 #define ZIVID_PYTHON_WRAP_ENUM_CLASS_BASE_IMPL(dest, name, source, callback)                                           \
     ZividPython::wrapEnum<source>(dest, name, callback)

--- a/test/test_matrix4x4.py
+++ b/test/test_matrix4x4.py
@@ -1,0 +1,314 @@
+from pathlib import Path
+import tempfile
+import numpy
+import numpy.testing
+import pytest
+import zivid
+
+ZIVID_MATRIX_SAVE_LOAD_TOLERANCE_DECIMAL = 5
+
+
+def to_float32_1d(arr):
+    for i, element in enumerate(arr):
+        arr[i] = float(numpy.float32(element))
+    return arr
+
+
+def to_float32_2d(arr):
+    for row in arr:
+        to_float32_1d(row)
+    return arr
+
+
+def assert_all_equal_flat(matrix: zivid.Matrix4x4, arr2) -> None:
+    assert isinstance(matrix, zivid.Matrix4x4)
+    assert len(arr2) == 16
+    for element1, element2 in zip(matrix, arr2):
+        numpy.testing.assert_almost_equal(
+            element1, element2, ZIVID_MATRIX_SAVE_LOAD_TOLERANCE_DECIMAL
+        )
+
+
+def assert_all_equal_2d(matrix: zivid.Matrix4x4, arr2) -> None:
+    assert isinstance(matrix, zivid.Matrix4x4)
+    assert not isinstance(arr2, zivid.Matrix4x4)
+    assert len(arr2) == 4
+    for row in range(4):
+        assert len(arr2[row]) == 4
+        for col in range(4):
+            numpy.testing.assert_almost_equal(
+                matrix[row, col],
+                arr2[row][col],
+                ZIVID_MATRIX_SAVE_LOAD_TOLERANCE_DECIMAL,
+            )
+
+
+def sample_2d_list() -> list:
+    return to_float32_2d(
+        [
+            [-8.3, 6.75, -2, 5.7],
+            [-0.24, 1.49, 3.5, -4.25],
+            [52, 0.98, 970.6, 75000],
+            [-64.3, 15.4, -84.4, -13.4],
+        ]
+    )
+
+
+def sample_1d_list() -> list:
+    return to_float32_1d(
+        [
+            3.8,
+            0.64,
+            -9.55,
+            63226,
+            -0.3445,
+            9.5,
+            4.004,
+            0.115,
+            9999,
+            -34,
+            14,
+            66.5,
+            87.4,
+            1.3,
+            36.2,
+            93.12,
+        ]
+    )
+
+
+def test_default_init():
+    assert_all_equal_flat(zivid.Matrix4x4(), [0.0] * 16)
+
+
+def test_flat_array_init():
+    assert_all_equal_flat(zivid.Matrix4x4(sample_1d_list()), sample_1d_list())
+    assert_all_equal_flat(
+        zivid.Matrix4x4(numpy.array(sample_1d_list())), numpy.array(sample_1d_list())
+    )
+
+    with pytest.raises(TypeError):
+        zivid.Matrix4x4(range(42))
+
+    with pytest.raises(TypeError):
+        zivid.Matrix4x4(range(0))
+
+
+def test_4x4_array_init():
+    assert_all_equal_2d(zivid.Matrix4x4(sample_2d_list()), sample_2d_list())
+    assert_all_equal_2d(
+        zivid.Matrix4x4(sample_2d_list()), numpy.array(sample_2d_list())
+    )
+
+    with pytest.raises(TypeError):
+        zivid.Matrix4x4([range(4), range(4, 9), range(9, 13), range(13, 17)])
+
+    with pytest.raises(TypeError):
+        zivid.Matrix4x4([[], range(4, 8), range(8, 12), range(12, 16)])
+
+    with pytest.raises(TypeError):
+        zivid.Matrix4x4([[]] * 4)
+
+
+def test_getitem():
+    matrix = zivid.Matrix4x4(sample_2d_list())
+
+    for i in range(4):
+        for j in range(4):
+            assert matrix[i, j] == sample_2d_list()[i][j]
+
+    for i in range(-4, 0):
+        for j in range(-4, 0):
+            assert matrix[i, j] == sample_2d_list()[i][j]
+
+    with pytest.raises(TypeError):
+        assert matrix[0] == 0
+
+    with pytest.raises(TypeError):
+        assert matrix[0, 0, 0] == 0
+
+    with pytest.raises(TypeError):
+        assert matrix[1.4, 1.0] == 0
+
+    with pytest.raises(TypeError):
+        assert matrix["0", "0"] == 0
+
+    with pytest.raises(IndexError):
+        assert matrix[1000, 0] == 0
+
+    with pytest.raises(IndexError):
+        assert matrix[0, 1000] == 0
+
+    with pytest.raises(IndexError):
+        assert matrix[0, -1000] == 0
+
+
+def test_setitem():
+    matrix = zivid.Matrix4x4()
+
+    for i in range(4):
+        for j in range(4):
+            matrix[i, j] = sample_2d_list()[i][j]
+            assert matrix[i, j] == sample_2d_list()[i][j]
+
+    assert_all_equal_2d(matrix, sample_2d_list())
+
+    for i in range(-4, 0):
+        for j in range(-4, 0):
+            matrix[i, j] = sample_2d_list()[i][j]
+            assert matrix[i, j] == sample_2d_list()[i][j]
+
+    assert_all_equal_2d(matrix, sample_2d_list())
+
+    with pytest.raises(TypeError):
+        matrix[0] = 0
+
+    with pytest.raises(TypeError):
+        matrix[0, 0, 0] = 0
+
+    with pytest.raises(TypeError):
+        matrix[1.4, 1.0] = 0
+
+    with pytest.raises(TypeError):
+        matrix["0", "0"] = 0
+
+    with pytest.raises(TypeError):
+        matrix[0, 0] = "42"
+
+    with pytest.raises(TypeError):
+        matrix[0, 0] = 10 ** 1000
+
+    with pytest.raises(IndexError):
+        matrix[1000, 0] = 0
+
+    with pytest.raises(IndexError):
+        matrix[0, 1000] = 0
+
+    with pytest.raises(IndexError):
+        matrix[0, -1000] = 0
+
+
+def test_rows_cols():
+    assert zivid.Matrix4x4.rows == 4
+    assert zivid.Matrix4x4.cols == 4
+    assert zivid.Matrix4x4().rows == 4
+    assert zivid.Matrix4x4().cols == 4
+
+    with pytest.raises(AttributeError):
+        zivid.Matrix4x4.rows = 3
+
+    with pytest.raises(AttributeError):
+        zivid.Matrix4x4.cols = 3
+
+
+def test_inverse():
+    def invertible_matrix():
+        return [
+            [1, 1, 1, -1],
+            [1, 1, -1, 1],
+            [1, -1, 1, 1],
+            [-1, 1, 1, 1],
+        ]
+
+    def non_invertible_matrix():
+        return [1] * 16
+
+    matrix = zivid.Matrix4x4(invertible_matrix())
+
+    assert_all_equal_2d(
+        matrix.inverse(),
+        [
+            [0.25, 0.25, 0.25, -0.25],
+            [0.25, 0.25, -0.25, 0.25],
+            [0.25, -0.25, 0.25, 0.25],
+            [-0.25, 0.25, 0.25, 0.25],
+        ],
+    )
+
+    assert_all_equal_2d(matrix, invertible_matrix())
+
+    matrix = zivid.Matrix4x4(non_invertible_matrix())
+
+    with pytest.raises(RuntimeError):
+        matrix.inverse()
+
+    assert_all_equal_flat(matrix, non_invertible_matrix())
+
+
+def test_buffer_protocol():
+    numpy_array = numpy.array(zivid.Matrix4x4(sample_2d_list()))
+    assert (numpy_array == sample_2d_list()).all()
+
+
+def test_to_string():
+    matrix = zivid.Matrix4x4(sample_2d_list())
+
+    assert str(matrix) == (
+        "[ [-8.300000,  6.750000, -2.000000,  5.700000], \n"
+        "  [-0.240000,  1.490000,  3.500000, -4.250000], \n"
+        "  [ 52.000000,  0.980000,  970.599976,  75000.000000], \n"
+        "  [-64.300003,  15.400000, -84.400002, -13.400000] ]"
+    )
+
+
+def test_save():
+    with tempfile.TemporaryDirectory() as tmpdir, zivid.Application() as _:
+        file = Path(tmpdir) / "matrix_saved.yml"
+        matrix = zivid.Matrix4x4(
+            to_float32_2d(
+                [
+                    [0.5, 1.34, -234, -3.43],
+                    [-4.31, 5343, 6.34, 7.12],
+                    [-8, -9, -10.3, 11.2],
+                    [1.2, 13.5, 1.4, 0.15],
+                ]
+            )
+        )
+        assert not file.exists()
+
+        matrix.save(file)
+
+        assert file.exists()
+
+        expected_content = (
+            "FloatMatrix:\n"
+            "  Data: [\n"
+            "    [0.5, 1.34, -234, -3.43],\n"
+            "    [-4.31, 5343, 6.34, 7.12],\n"
+            "    [-8, -9, -10.3, 11.2],\n"
+            "    [1.2, 13.5, 1.4, 0.15]]\n"
+        )
+
+        with open(file, "r", encoding="utf8") as file:
+            assert expected_content in file.read()
+
+
+def test_load():
+    with tempfile.TemporaryDirectory() as tmpdir, zivid.Application() as _:
+        file = Path(tmpdir) / "matrix_saved.yml"
+        zivid.Matrix4x4(sample_2d_list()).save(file)
+        matrix = zivid.Matrix4x4()
+        matrix.load(file)
+        assert_all_equal_2d(matrix, sample_2d_list())
+
+
+def test_file_init():
+    with tempfile.TemporaryDirectory() as tmpdir, zivid.Application() as _:
+        file = Path(tmpdir) / "matrix_saved.yml"
+        zivid.Matrix4x4(sample_2d_list()).save(file)
+        assert_all_equal_2d(zivid.Matrix4x4(file), sample_2d_list())
+
+
+def test_implicit_convert_to_numpy():
+    sample = to_float32_2d(
+        [
+            [1.0, 0.0, 0.0, 10.0],
+            [0.0, 0.0, -1.0, 20.0],
+            [0.0, 1.0, 0.0, 30.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    pose1 = zivid.calibration.Pose(zivid.Matrix4x4(sample))
+    pose2 = zivid.calibration.Pose(numpy.array(sample))
+
+    assert_all_equal_2d(zivid.Matrix4x4(pose1.to_matrix()), pose2.to_matrix())


### PR DESCRIPTION
The Matrix4x4 API is largely similar to that of the native C++ version. But the Matrix4x4 objects are convertible to and from numpy.ndarray:

```
matrix = zivid.Matrix4x4(...)
numpy_array = numpy.array(matrix)
matrix = zivid.Matrix4x4(numpy_array)
```

All our API functions that work with numpy arrays also work with zivid.Matrix4x4. In addition, all numpy functions that expect numpy.ndarray of float32[4, 4] also work with zivid.Matrix4x4.