### PR TITLE
Windows: Ignore TemporaryDirectory errors

### DIFF
--- a/continuous-integration/windows/backports.py
+++ b/continuous-integration/windows/backports.py
@@ -1,0 +1,118 @@
+# Backported from python 3.10
+# https://github.com/python/cpython/blob/75a6fadf369315b27e12f670e6295cf2c2cf7d7e/Lib/tempfile.py#L844
+
+""" 
+1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and
+   the Individual or Organization ("Licensee") accessing and otherwise using Python
+   3.10.8 software in source or binary form and its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+   grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+   analyze, test, perform and/or display publicly, prepare derivative works,
+   distribute, and otherwise use Python 3.10.8 alone or in any derivative
+   version, provided, however, that PSF's License Agreement and PSF's notice of
+   copyright, i.e., "Copyright © 2001-2022 Python Software Foundation; All Rights
+   Reserved" are retained in Python 3.10.8 alone or in any derivative version
+   prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on or
+   incorporates Python 3.10.8 or any part thereof, and wants to make the
+   derivative work available to others as provided herein, then Licensee hereby
+   agrees to include in any such work a brief summary of the changes made to Python
+   3.10.8.
+
+4. PSF is making Python 3.10.8 available to Licensee on an "AS IS" basis.
+   PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF
+   EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR
+   WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE
+   USE OF PYTHON 3.10.8 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.10.8
+   FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF
+   MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.10.8, OR ANY DERIVATIVE
+   THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material breach of
+   its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any relationship
+   of agency, partnership, or joint venture between PSF and Licensee.  This License
+   Agreement does not grant permission to use PSF trademarks or trade name in a
+   trademark sense to endorse or promote products or services of Licensee, or any
+   third party.
+
+8. By copying, installing or otherwise using Python 3.10.8, Licensee agrees
+   to be bound by the terms and conditions of this License Agreement.
+ """
+
+import tempfile
+
+class TemporaryDirectory:
+    """Create and return a temporary directory.  This has the same
+    behavior as mkdtemp but can be used as a context manager.  For
+    example:
+        with TemporaryDirectory() as tmpdir:
+            ...
+    Upon exiting the context, the directory and everything contained
+    in it are removed.
+    """
+
+    def __init__(self, suffix=None, prefix=None, dir=None,
+                 ignore_cleanup_errors=False):
+        self.name = mkdtemp(suffix, prefix, dir)
+        self._ignore_cleanup_errors = ignore_cleanup_errors
+        self._finalizer = _weakref.finalize(
+            self, self._cleanup, self.name,
+            warn_message="Implicitly cleaning up {!r}".format(self),
+            ignore_errors=self._ignore_cleanup_errors)
+
+    @classmethod
+    def _rmtree(cls, name, ignore_errors=False):
+        def onerror(func, path, exc_info):
+            if issubclass(exc_info[0], PermissionError):
+                def resetperms(path):
+                    try:
+                        _os.chflags(path, 0)
+                    except AttributeError:
+                        pass
+                    _os.chmod(path, 0o700)
+
+                try:
+                    if path != name:
+                        resetperms(_os.path.dirname(path))
+                    resetperms(path)
+
+                    try:
+                        _os.unlink(path)
+                    # PermissionError is raised on FreeBSD for directories
+                    except (IsADirectoryError, PermissionError):
+                        cls._rmtree(path, ignore_errors=ignore_errors)
+                except FileNotFoundError:
+                    pass
+            elif issubclass(exc_info[0], FileNotFoundError):
+                pass
+            else:
+                if not ignore_errors:
+                    raise
+
+        _shutil.rmtree(name, onerror=onerror)
+
+    @classmethod
+    def _cleanup(cls, name, warn_message, ignore_errors=False):
+        cls._rmtree(name, ignore_errors=ignore_errors)
+        _warnings.warn(warn_message, ResourceWarning)
+
+    def __repr__(self):
+        return "<{} {!r}>".format(self.__class__.__name__, self.name)
+
+    def __enter__(self):
+        return self.name
+
+    def __exit__(self, exc, value, tb):
+        self.cleanup()
+
+    def cleanup(self):
+        if self._finalizer.detach() or _os.path.exists(self.name):
+            self._rmtree(self.name, ignore_errors=self._ignore_cleanup_errors)
+
+    __class_getitem__ = classmethod(_types.GenericAlias)

--- a/continuous-integration/windows/setup.py
+++ b/continuous-integration/windows/setup.py
@@ -8,7 +8,7 @@ from common import repo_root, run_process, install_pip_dependencies
 def _install_zivid_sdk():
     import requests  # pylint: disable=import-outside-toplevel
 
-    with tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         zivid_installer_url = "https://www.zivid.com/hubfs/softwarefiles/releases/2.8.0+891708ba-1/windows/ZividSetup_2.8.0+891708ba-1.exe"
         print("Downloading {}".format(zivid_installer_url), flush=True)
         zivid_installer = Path(temp_dir) / "ZividSetup.exe"
@@ -21,7 +21,7 @@ def _install_zivid_sdk():
 def _install_intel_opencl_runtime():
     import requests  # pylint: disable=import-outside-toplevel
 
-    with tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         intel_opencl_runtime_url = "https://www.dropbox.com/s/09bk2nx31hzrupf/opencl_runtime_18.1_x64_setup-20200625-090300.msi?raw=1"
         print("Downloading {}".format(intel_opencl_runtime_url), flush=True)
         opencl_runtime = Path(temp_dir) / "opencl_runtime.msi"

--- a/continuous-integration/windows/setup.py
+++ b/continuous-integration/windows/setup.py
@@ -1,14 +1,14 @@
 import os
-import tempfile
 import shutil
 from pathlib import Path
+from backports import TemporaryDirectory
 from common import repo_root, run_process, install_pip_dependencies
 
 
 def _install_zivid_sdk():
     import requests  # pylint: disable=import-outside-toplevel
 
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+    with TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         zivid_installer_url = "https://www.zivid.com/hubfs/softwarefiles/releases/2.8.0+891708ba-1/windows/ZividSetup_2.8.0+891708ba-1.exe"
         print("Downloading {}".format(zivid_installer_url), flush=True)
         zivid_installer = Path(temp_dir) / "ZividSetup.exe"
@@ -21,7 +21,7 @@ def _install_zivid_sdk():
 def _install_intel_opencl_runtime():
     import requests  # pylint: disable=import-outside-toplevel
 
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+    with TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         intel_opencl_runtime_url = "https://www.dropbox.com/s/09bk2nx31hzrupf/opencl_runtime_18.1_x64_setup-20200625-090300.msi?raw=1"
         print("Downloading {}".format(intel_opencl_runtime_url), flush=True)
         opencl_runtime = Path(temp_dir) / "opencl_runtime.msi"


### PR DESCRIPTION
It is not a big deal if the cleanup of installers fails, as the job runners are ephemeral. Ignoring it is better than retrying with a backoff and holding a runner for longer than needed.

MISC

---

When necessary, projects like https://github.com/pypa/pip/pull/2397 do implement a retry.