### PR TITLE
Simplify test matrix table

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,16 +153,16 @@ Please visit [Zivid Knowledge Base][zivid-knowledge-base-url] for general inform
 
 ## Test matrix
 
-| Operating System | Python version            | Zivid SDK version |
-| :--------------- | :------------------------ | :---------------- |
-| Ubuntu 20.04     | 3.8                       | 2.8.0             |
-| Ubuntu 18.04     | 3.6                       | 2.8.0             |
-| Fedora 30        | 3.7                       | 2.8.0             |
-| Fedora 33        | 3.9                       | 2.8.0             |
-| Fedora 34        | 3.9                       | 2.8.0             |
-| Fedora 35        | 3.10                      | 2.8.0             |
-| Windows 10       | 3.7, 3.8, 3.9, 3.10, 3.11 | 2.8.0             |
-| Arch Linux       | latest                    | 2.8.0             |
+| Operating System | Python version            |
+| :--------------- | :------------------------ |
+| Ubuntu 20.04     | 3.8                       |
+| Ubuntu 18.04     | 3.6                       |
+| Fedora 30        | 3.7                       |
+| Fedora 33        | 3.9                       |
+| Fedora 34        | 3.9                       |
+| Fedora 35        | 3.10                      |
+| Windows 10       | 3.7, 3.8, 3.9, 3.10, 3.11 |
+| Arch Linux       | latest                    |
 
 [header-image]: https://www.zivid.com/hubfs/softwarefiles/images/zivid-generic-github-header.png
 [ci-badge]: https://img.shields.io/github/workflow/status/zivid/zivid-python/Main%20CI%20workflow/master


### PR DESCRIPTION
Listing the SDK version in the test matrix is not really useful. Each commit of `zivid-python` supports exactly one version of the SDK, and that version is stated further up in the README anyway. Simplifying this will reduce the manual work of bumping the supported SDK version.