### PR TITLE
Specify which Python versions are supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Zivid Python is the official Python package for Zivid 3D cameras. Read more abou
 
 ### Dependencies
 
-* [Python](https://www.python.org/) version 3.6 or higher
+* [Python](https://www.python.org/) version 3.6, 3.7, 3.8, 3.9 and 3.10
 * [Zivid SDK][zivid-download-software-url] version 2.8.0 (see [here][zivid-software-installation-url] for help)
 * [Compiler](doc/CompilerInstallation.md) with C++17 support
 

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,11 @@ def _main():
         ],
         classifiers=[
             "License :: OSI Approved :: BSD License",
-            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: Implementation :: CPython",
             "Topic :: Scientific/Engineering",
         ],


### PR DESCRIPTION
Clarify exactly which Python versions are supported, and add the classifiers that makes it clear in the sidebar on pypi.org.