### PR TITLE
Allow construction of Matrix4x4 directly from Pose

### DIFF
--- a/modules/zivid/matrix4x4.py
+++ b/modules/zivid/matrix4x4.py
@@ -1,6 +1,7 @@
 """Contains Matrix4x4 class."""
 import pathlib
 import _zivid
+from zivid.calibration import Pose
 
 
 class Matrix4x4(_zivid.Matrix4x4):
@@ -15,6 +16,7 @@ class Matrix4x4(_zivid.Matrix4x4):
         * None or no arguments -> Zero initializes all values.
         * 1 dimensional List or numpy.ndarray of 16 floats -> Map 1D array of 16 values into this 2D array of 4x4.
         * 2 dimensional List or numpy.ndarray of 4x4 floats -> Copy 2D array of size 4x4.
+        * Instance of zivid.calibration.Pose -> Copy of the matrix contained in the Pose
         * str or pathlib.Path -> Load the matrix from a file.
 
         Args:
@@ -22,6 +24,8 @@ class Matrix4x4(_zivid.Matrix4x4):
         """
         if arg is None:
             super().__init__()
+        elif isinstance(arg, Pose):
+            super().__init__(arg.to_matrix())
         elif isinstance(arg, pathlib.Path):
             super().__init__(str(arg))
         else:

--- a/test/test_matrix4x4.py
+++ b/test/test_matrix4x4.py
@@ -77,6 +77,18 @@ def sample_1d_list() -> list:
     )
 
 
+def sample_transformation_matrix() -> numpy.ndarray:
+
+    return numpy.array(
+        [
+            [1.0, 0.0, 0.0, 150.0],
+            [0.0, 1.0, 0.0, 160.0],
+            [0.0, 0.0, 1.0, 250.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+
+
 def test_default_init():
     assert_all_equal_flat(zivid.Matrix4x4(), [0.0] * 16)
 
@@ -108,6 +120,12 @@ def test_4x4_array_init():
 
     with pytest.raises(TypeError):
         zivid.Matrix4x4([[]] * 4)
+
+
+def test_pose_init():
+    pose = zivid.calibration.Pose(sample_transformation_matrix())
+    matrix = zivid.Matrix4x4(pose)
+    assert_all_equal_2d(matrix, sample_transformation_matrix())
 
 
 def test_getitem():


### PR DESCRIPTION
Functions such as `DetectionResult.pose()` return a `Pose`, not a numpy array. The user may want to save this pose to file, which could only be done by:
```
zivid.Matrix4x4(pose.to_matrix()).save("mypose.yml")
```

This commit makes the process easier by enabling:
```
zivid.Matrix4x4(pose).save("mypose.yml")
```