### PR TITLE
Pin conan version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # Keep the two lists in sync
 requires = [
     "cmake",
-    "conan",
+    "conan>=1,<2",
     "ninja",
     "scikit-build",
     ]


### PR DESCRIPTION
Conan 2.0 was released today and breaks zivid-python with the following error message due to a change in Conan's API:

```
conan install: error: unrecognized arguments: --install-folder
```

This change pins Conan to 1.x and fixes the issue.