### PR TITLE
De-duplicate exact SDK version used in CI

### DIFF
--- a/continuous-integration/linux/platform-dependent/common.sh
+++ b/continuous-integration/linux/platform-dependent/common.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(realpath $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) )"
+
 function install_opencl_cpu_runtime {
     TMP_DIR=$(mktemp --tmpdir --directory zivid-setup-opencl-cpu-XXXX) || exit $?
     pushd $TMP_DIR || exit $?
@@ -28,3 +30,10 @@ EOF
     popd || exit $?
     rm -r $TMP_DIR || exit $?
 }
+
+# Read versions.json and set as environment variables
+VERSIONS_FILE="${SCRIPT_DIR}/../../versions.json"
+for var in $(jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" ${VERSIONS_FILE} ); do
+    echo "Setting env var from ${VERSIONS_FILE}: ${var}"
+    export ${var?}
+done

--- a/continuous-integration/linux/platform-dependent/fedora-30/setup.sh
+++ b/continuous-integration/linux/platform-dependent/fedora-30/setup.sh
@@ -6,6 +6,7 @@ dnf --assumeyes install \
     bsdtar \
     clinfo \
     g++ \
+    jq \
     libatomic \
     python3-devel \
     python3-pip \
@@ -34,5 +35,5 @@ function install_www_deb {
     rm -r $TMP_DIR || exit $?
 }
 
-install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/u18/zivid-telicam-driver_3.0.1.1-3_amd64.deb || exit $?
-install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/u18/zivid_2.8.1+dd4dffea-1_amd64.deb || exit $?
+install_www_deb "https://www.zivid.com/hubfs/softwarefiles/releases/${ZIVID_SDK_EXACT_VERSION}/u18/zivid-telicam-driver_${ZIVID_TELICAM_EXACT_VERSION}_amd64.deb" || exit $?
+install_www_deb "https://www.zivid.com/hubfs/softwarefiles/releases/${ZIVID_SDK_EXACT_VERSION}/u18/zivid_${ZIVID_SDK_EXACT_VERSION}_amd64.deb" || exit $?

--- a/continuous-integration/linux/platform-dependent/fedora-33/setup.sh
+++ b/continuous-integration/linux/platform-dependent/fedora-33/setup.sh
@@ -6,6 +6,7 @@ dnf --assumeyes install \
     bsdtar \
     clinfo \
     g++ \
+    jq \
     libatomic \
     python3-devel \
     python3-pip \
@@ -34,5 +35,5 @@ function install_www_deb {
     rm -r $TMP_DIR || exit $?
 }
 
-install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/u18/zivid-telicam-driver_3.0.1.1-3_amd64.deb || exit $?
-install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/u18/zivid_2.8.1+dd4dffea-1_amd64.deb || exit $?
+install_www_deb "https://www.zivid.com/hubfs/softwarefiles/releases/${ZIVID_SDK_EXACT_VERSION}/u18/zivid-telicam-driver_${ZIVID_TELICAM_EXACT_VERSION}_amd64.deb" || exit $?
+install_www_deb "https://www.zivid.com/hubfs/softwarefiles/releases/${ZIVID_SDK_EXACT_VERSION}/u18/zivid_${ZIVID_SDK_EXACT_VERSION}_amd64.deb" || exit $?

--- a/continuous-integration/linux/platform-dependent/fedora-34/setup.sh
+++ b/continuous-integration/linux/platform-dependent/fedora-34/setup.sh
@@ -6,6 +6,7 @@ dnf --assumeyes install \
     bsdtar \
     clinfo \
     g++ \
+    jq \
     libatomic \
     python3-devel \
     python3-pip \
@@ -34,5 +35,5 @@ function install_www_deb {
     rm -r $TMP_DIR || exit $?
 }
 
-install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/u20/zivid-telicam-driver_3.0.1.1-3_amd64.deb || exit $?
-install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/u20/zivid_2.8.1+dd4dffea-1_amd64.deb || exit $?
+install_www_deb "https://www.zivid.com/hubfs/softwarefiles/releases/${ZIVID_SDK_EXACT_VERSION}/u20/zivid-telicam-driver_${ZIVID_TELICAM_EXACT_VERSION}_amd64.deb" || exit $?
+install_www_deb "https://www.zivid.com/hubfs/softwarefiles/releases/${ZIVID_SDK_EXACT_VERSION}/u20/zivid_${ZIVID_SDK_EXACT_VERSION}_amd64.deb" || exit $?

--- a/continuous-integration/linux/platform-dependent/fedora-35/setup.sh
+++ b/continuous-integration/linux/platform-dependent/fedora-35/setup.sh
@@ -6,6 +6,7 @@ dnf --assumeyes install \
     bsdtar \
     clinfo \
     g++ \
+    jq \
     libatomic \
     python3-devel \
     python3-pip \
@@ -34,5 +35,5 @@ function install_www_deb {
     rm -r $TMP_DIR || exit $?
 }
 
-install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/u20/zivid-telicam-driver_3.0.1.1-3_amd64.deb || exit $?
-install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/u20/zivid_2.8.1+dd4dffea-1_amd64.deb || exit $?
+install_www_deb "https://www.zivid.com/hubfs/softwarefiles/releases/${ZIVID_SDK_EXACT_VERSION}/u20/zivid-telicam-driver_${ZIVID_TELICAM_EXACT_VERSION}_amd64.deb" || exit $?
+install_www_deb "https://www.zivid.com/hubfs/softwarefiles/releases/${ZIVID_SDK_EXACT_VERSION}/u20/zivid_${ZIVID_SDK_EXACT_VERSION}_amd64.deb" || exit $?

--- a/continuous-integration/linux/platform-dependent/ubuntu-18.04/setup.sh
+++ b/continuous-integration/linux/platform-dependent/ubuntu-18.04/setup.sh
@@ -13,6 +13,7 @@ apt-yes dist-upgrade || exit $?
 apt-yes install \
     clinfo \
     g++ \
+    jq \
     python3-dev \
     python3-venv \
     python3-pip \
@@ -36,5 +37,5 @@ function install_www_deb {
     rm -r $TMP_DIR || exit $?
 }
 
-install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/u18/zivid-telicam-driver_3.0.1.1-3_amd64.deb || exit $?
-install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/u18/zivid_2.8.1+dd4dffea-1_amd64.deb || exit $?
+install_www_deb "https://www.zivid.com/hubfs/softwarefiles/releases/${ZIVID_SDK_EXACT_VERSION}/u18/zivid-telicam-driver_${ZIVID_TELICAM_EXACT_VERSION}_amd64.deb" || exit $?
+install_www_deb "https://www.zivid.com/hubfs/softwarefiles/releases/${ZIVID_SDK_EXACT_VERSION}/u18/zivid_${ZIVID_SDK_EXACT_VERSION}_amd64.deb" || exit $?

--- a/continuous-integration/linux/platform-dependent/ubuntu-20.04/setup.sh
+++ b/continuous-integration/linux/platform-dependent/ubuntu-20.04/setup.sh
@@ -13,6 +13,7 @@ apt-yes dist-upgrade || exit $?
 apt-yes install \
     clinfo \
     g++ \
+    jq \
     python3-dev \
     python3-venv \
     python3-pip \
@@ -36,5 +37,5 @@ function install_www_deb {
     rm -r $TMP_DIR || exit $?
 }
 
-install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/u20/zivid-telicam-driver_3.0.1.1-3_amd64.deb || exit $?
-install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/u20/zivid_2.8.1+dd4dffea-1_amd64.deb || exit $?
+install_www_deb "https://www.zivid.com/hubfs/softwarefiles/releases/${ZIVID_SDK_EXACT_VERSION}/u20/zivid-telicam-driver_${ZIVID_TELICAM_EXACT_VERSION}_amd64.deb" || exit $?
+install_www_deb "https://www.zivid.com/hubfs/softwarefiles/releases/${ZIVID_SDK_EXACT_VERSION}/u20/zivid_${ZIVID_SDK_EXACT_VERSION}_amd64.deb" || exit $?

--- a/continuous-integration/linux/platform-dependent/ubuntu-22.04/setup.sh
+++ b/continuous-integration/linux/platform-dependent/ubuntu-22.04/setup.sh
@@ -13,6 +13,7 @@ apt-yes dist-upgrade || exit $?
 apt-yes install \
     clinfo \
     g++ \
+    jq \
     python3-dev \
     python3-venv \
     python3-pip \
@@ -36,5 +37,5 @@ function install_www_deb {
     rm -r $TMP_DIR || exit $?
 }
 
-install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/u22/zivid-telicam-driver_3.0.1.1-3_amd64.deb || exit $?
-install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/u22/zivid_2.8.1+dd4dffea-1_amd64.deb || exit $?
+install_www_deb "https://www.zivid.com/hubfs/softwarefiles/releases/${ZIVID_SDK_EXACT_VERSION}/u22/zivid-telicam-driver_${ZIVID_TELICAM_EXACT_VERSION}_amd64.deb" || exit $?
+install_www_deb "https://www.zivid.com/hubfs/softwarefiles/releases/${ZIVID_SDK_EXACT_VERSION}/u22/zivid_${ZIVID_SDK_EXACT_VERSION}_amd64.deb" || exit $?

--- a/continuous-integration/versions.json
+++ b/continuous-integration/versions.json
@@ -1,0 +1,4 @@
+{
+    "ZIVID_SDK_EXACT_VERSION": "2.8.1+dd4dffea-1",
+    "ZIVID_TELICAM_EXACT_VERSION": "3.0.1.1-3"
+}

--- a/continuous-integration/windows/setup.py
+++ b/continuous-integration/windows/setup.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 import shutil
@@ -8,8 +9,13 @@ from common import repo_root, run_process, install_pip_dependencies
 def _install_zivid_sdk():
     import requests  # pylint: disable=import-outside-toplevel
 
+    versions_json = (Path(__file__).parents[1] / "versions.json").read_text(
+        encoding="utf8"
+    )
+    exact_version = json.loads(versions_json)["ZIVID_SDK_EXACT_VERSION"]
+
     with tempfile.TemporaryDirectory() as temp_dir:
-        zivid_installer_url = "https://www.zivid.com/hubfs/softwarefiles/releases/2.8.1+dd4dffea-1/windows/ZividSetup_2.8.1+dd4dffea-1.exe"
+        zivid_installer_url = f"https://www.zivid.com/hubfs/softwarefiles/releases/{exact_version}/windows/ZividSetup_{exact_version}.exe"
         print("Downloading {}".format(zivid_installer_url), flush=True)
         zivid_installer = Path(temp_dir) / "ZividSetup.exe"
         response = requests.get(zivid_installer_url)


### PR DESCRIPTION
Version strings like `2.8.1+dd4dffea-1` are used to choose which SDK installers are downloaded in the CI worflows. These were unnecessarily duplicated across many files. This commit defines them in a single place, so that future commits that bumps SDK version can be simpler.