### PR TITLE
Add `Frame2D.camera_info` property

### DIFF
--- a/modules/zivid/frame_2d.py
+++ b/modules/zivid/frame_2d.py
@@ -1,6 +1,7 @@
 """Contains the Frame class."""
 import _zivid
 from zivid.settings_2d import _to_settings2d
+from zivid.camera_info import _to_camera_info
 from zivid.camera_state import _to_camera_state
 from zivid.frame_info import _to_frame_info
 from zivid.image import Image
@@ -69,6 +70,15 @@ class Frame2D:
             A FrameInfo instance
         """
         return _to_frame_info(self.__impl.info)
+
+    @property
+    def camera_info(self):
+        """Get information about the camera used to capture the frame.
+
+        Returns:
+            A CameraInfo instance
+        """
+        return _to_camera_info(self.__impl.camera_info)
 
     def release(self):
         """Release the underlying resources."""

--- a/src/ReleasableFrame2D.cpp
+++ b/src/ReleasableFrame2D.cpp
@@ -11,6 +11,7 @@ namespace ZividPython
         pyClass.def_property_readonly("settings", &ReleasableFrame2D::settings)
             .def_property_readonly("state", &ReleasableFrame2D::state)
             .def_property_readonly("info", &ReleasableFrame2D::info)
+            .def_property_readonly("camera_info", &ReleasableFrame2D::cameraInfo)
             .def("image_rgba", &ReleasableFrame2D::imageRGBA);
     }
 } // namespace ZividPython

--- a/src/include/ZividPython/ReleasableFrame2D.h
+++ b/src/include/ZividPython/ReleasableFrame2D.h
@@ -18,6 +18,7 @@ namespace ZividPython
         ZIVID_PYTHON_FORWARD_0_ARGS(settings)
         ZIVID_PYTHON_FORWARD_0_ARGS(state)
         ZIVID_PYTHON_FORWARD_0_ARGS(info)
+        ZIVID_PYTHON_FORWARD_0_ARGS(cameraInfo)
     };
 
     void wrapClass(pybind11::class_<ReleasableFrame2D> pyClass);

--- a/test/test_frame_2d.py
+++ b/test/test_frame_2d.py
@@ -38,6 +38,15 @@ def test_info(physical_camera_frame_2d):
 
 
 @pytest.mark.physical_camera
+def test_camera_info(physical_camera_frame_2d):
+    from zivid.camera_info import CameraInfo
+
+    camera_info = physical_camera_frame_2d.camera_info
+    assert camera_info
+    assert isinstance(camera_info, CameraInfo)
+
+
+@pytest.mark.physical_camera
 def test_settings(physical_camera_frame_2d):
     import zivid
 


### PR DESCRIPTION
In SDK 2.9 `Frame2D` was extended with a `CameraInfo` getter, similar to what `Frame` already had. This commit exposes this to zivid-python.