### PR TITLE
Start testing 2D capture API in the CI

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -46,6 +46,11 @@ def default_settings_fixture():
     return zivid.Settings(acquisitions=[zivid.Settings.Acquisition()])
 
 
+@pytest.fixture(name="default_settings_2d", scope="module")
+def default_settings_2d_fixture():
+    return zivid.Settings2D(acquisitions=[zivid.Settings2D.Acquisition()])
+
+
 @pytest.fixture(name="frame_file", scope="module")
 def frame_file_fixture(application, file_camera, default_settings):
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -92,6 +97,12 @@ def frame_fixture(application, file_camera, default_settings):
         yield frame
 
 
+@pytest.fixture(name="frame_2d", scope="function")
+def frame_2d_fixture(application, file_camera, default_settings_2d):
+    with file_camera.capture(default_settings_2d) as frame2d:
+        yield frame2d
+
+
 @pytest.fixture(name="point_cloud", scope="function")
 def point_cloud_fixture(frame):
     with frame.point_cloud() as point_cloud:
@@ -113,22 +124,15 @@ def handeye_eth_transform_fixture():
     return np.loadtxt(str(path), delimiter=",")
 
 
-@pytest.fixture(name="physical_camera_frame_2d", scope="function")
-def physical_camera_frame_2d_fixture(physical_camera):
-    settings_2d = zivid.Settings2D(acquisitions=[zivid.Settings2D.Acquisition()])
-    with physical_camera.capture(settings_2d) as frame_2d:
-        yield frame_2d
-
-
-@pytest.fixture(name="physical_camera_image_2d_rgba", scope="function")
-def physical_camera_image_2d_rgba_fixture(physical_camera_frame_2d):
-    with physical_camera_frame_2d.image_rgba() as image_2d_rgb:
+@pytest.fixture(name="image_2d_rgba", scope="function")
+def image_2d_rgba_fixture(frame_2d):
+    with frame_2d.image_rgba() as image_2d_rgb:
         yield image_2d_rgb
 
 
-@pytest.fixture(name="physical_camera_image_2d_bgra", scope="function")
-def physical_camera_image_2d_bgra_fixture(physical_camera_frame_2d):
-    with physical_camera_frame_2d.image_bgra() as image_2d_bgr:
+@pytest.fixture(name="image_2d_bgra", scope="function")
+def image_2d_bgra_fixture(frame_2d):
+    with frame_2d.image_bgra() as image_2d_bgr:
         yield image_2d_bgr
 
 

--- a/test/test_camera.py
+++ b/test/test_camera.py
@@ -104,14 +104,3 @@ def test_state(file_camera):
     state = file_camera.state
     assert state
     assert isinstance(state, zivid.CameraState)
-
-
-@pytest.mark.physical_camera
-def test_capture_2d(physical_camera):
-    import zivid
-
-    settings_2d = zivid.Settings2D(acquisitions=[zivid.Settings2D.Acquisition()])
-
-    frame_2d = physical_camera.capture(settings_2d)
-    assert frame_2d is not None
-    assert isinstance(frame_2d, zivid.Frame2D)

--- a/test/test_frame_2d.py
+++ b/test/test_frame_2d.py
@@ -2,36 +2,33 @@ import numpy as np
 import pytest
 
 
-@pytest.mark.physical_camera
-def test_image_context_manager(physical_camera_frame_2d):
+def test_image_context_manager(frame_2d):
     import zivid
 
-    with physical_camera_frame_2d.image_rgba() as image_rgba:
+    with frame_2d.image_rgba() as image_rgba:
         assert image_rgba is not None
         assert isinstance(image_rgba, zivid.Image)
 
-    with physical_camera_frame_2d.image_bgra() as image_bgra:
+    with frame_2d.image_bgra() as image_bgra:
         assert image_bgra is not None
         assert isinstance(image_bgra, zivid.Image)
 
 
-@pytest.mark.physical_camera
-def test_image(physical_camera_frame_2d):
+def test_image(frame_2d):
     import zivid
 
-    image_rgba = physical_camera_frame_2d.image_rgba()
+    image_rgba = frame_2d.image_rgba()
     assert image_rgba is not None
     assert isinstance(image_rgba, zivid.Image)
 
-    image_bgra = physical_camera_frame_2d.image_bgra()
+    image_bgra = frame_2d.image_bgra()
     assert image_bgra is not None
     assert isinstance(image_bgra, zivid.Image)
 
 
-@pytest.mark.physical_camera
-def test_image_rgba_bgra_correspondence(physical_camera_frame_2d):
-    rgba = physical_camera_frame_2d.image_rgba().copy_data()
-    bgra = physical_camera_frame_2d.image_bgra().copy_data()
+def test_image_rgba_bgra_correspondence(frame_2d):
+    rgba = frame_2d.image_rgba().copy_data()
+    bgra = frame_2d.image_bgra().copy_data()
 
     np.testing.assert_array_equal(bgra[:, :, 0], rgba[:, :, 2])
     np.testing.assert_array_equal(bgra[:, :, 1], rgba[:, :, 1])
@@ -39,61 +36,55 @@ def test_image_rgba_bgra_correspondence(physical_camera_frame_2d):
     np.testing.assert_array_equal(bgra[:, :, 3], rgba[:, :, 3])
 
 
-@pytest.mark.physical_camera
-def test_state(physical_camera_frame_2d):
+def test_state(frame_2d):
     import zivid
 
-    state = physical_camera_frame_2d.state
+    state = frame_2d.state
     assert state is not None
     assert isinstance(state, zivid.CameraState)
 
 
-@pytest.mark.physical_camera
-def test_info(physical_camera_frame_2d):
+def test_info(frame_2d):
     import zivid
 
-    info = physical_camera_frame_2d.info
+    info = frame_2d.info
     assert info is not None
     assert isinstance(info, zivid.FrameInfo)
 
 
-@pytest.mark.physical_camera
-def test_camera_info(physical_camera_frame_2d):
+def test_camera_info(frame_2d):
     from zivid.camera_info import CameraInfo
 
-    camera_info = physical_camera_frame_2d.camera_info
+    camera_info = frame_2d.camera_info
     assert camera_info
     assert isinstance(camera_info, CameraInfo)
 
 
-@pytest.mark.physical_camera
-def test_settings(physical_camera_frame_2d):
+def test_settings(frame_2d):
     import zivid
 
-    settings_2d = physical_camera_frame_2d.settings
+    settings_2d = frame_2d.settings
     assert settings_2d is not None
     assert isinstance(settings_2d, zivid.Settings2D)
 
 
-@pytest.mark.physical_camera
-def test_release(physical_camera_frame_2d):
-    physical_camera_frame_2d.image_rgba()
-    physical_camera_frame_2d.release()
+def test_release(frame_2d):
+    frame_2d.image_rgba()
+    frame_2d.release()
     with pytest.raises(RuntimeError):
-        physical_camera_frame_2d.image_rgba()
+        frame_2d.image_rgba()
 
 
-@pytest.mark.physical_camera
-def test_context_manager(physical_camera):
+def test_context_manager(file_camera):
     import zivid
 
     settings_2d = zivid.Settings2D(acquisitions=[zivid.Settings2D.Acquisition()])
-    with physical_camera.capture(settings_2d) as frame_2d:
+    with file_camera.capture(settings_2d) as frame_2d:
         frame_2d.image_rgba()
     with pytest.raises(RuntimeError):
         frame_2d.image_rgba()
 
-    with physical_camera.capture(settings_2d) as frame_2d:
+    with file_camera.capture(settings_2d) as frame_2d:
         frame_2d.image_bgra()
     with pytest.raises(RuntimeError):
         frame_2d.image_bgra()

--- a/test/test_image_2d_bgra.py
+++ b/test/test_image_2d_bgra.py
@@ -1,11 +1,10 @@
 import pytest
 
 
-@pytest.mark.physical_camera
-def test_copy_data(physical_camera_image_2d_bgra):
+def test_copy_data(image_2d_bgra):
     import numpy as np
 
-    image = physical_camera_image_2d_bgra
+    image = image_2d_bgra
     bgra = image.copy_data()
     assert bgra is not None
     assert isinstance(bgra, np.ndarray)
@@ -13,45 +12,39 @@ def test_copy_data(physical_camera_image_2d_bgra):
     assert bgra.dtype == np.uint8
 
 
-@pytest.mark.physical_camera
-def test_save_path(physical_camera_image_2d_bgra):
+def test_save_path(image_2d_bgra):
     from pathlib import Path
 
-    physical_camera_image_2d_bgra.save(Path("some_file.png"))
+    image_2d_bgra.save(Path("some_file.png"))
 
 
-@pytest.mark.physical_camera
-def test_save_string(physical_camera_image_2d_bgra):
-    physical_camera_image_2d_bgra.save("some_file.png")
+def test_save_string(image_2d_bgra):
+    image_2d_bgra.save("some_file.png")
 
 
-@pytest.mark.physical_camera
-def test_to_array_context_manager(physical_camera_frame_2d):
-    with physical_camera_frame_2d.image_bgra() as image_2d:
+def test_to_array_context_manager(frame_2d):
+    with frame_2d.image_bgra() as image_2d:
         image_2d.copy_data()
     with pytest.raises(RuntimeError):
         image_2d.copy_data()
 
 
-@pytest.mark.physical_camera
-def test_save_context_manager(physical_camera_frame_2d):
-    with physical_camera_frame_2d.image_bgra() as image_2d:
+def test_save_context_manager(frame_2d):
+    with frame_2d.image_bgra() as image_2d:
         image_2d.save("some_file.png")
     with pytest.raises(RuntimeError):
         image_2d.save("some_file.png")
 
 
-@pytest.mark.physical_camera
-def test_height(physical_camera_image_2d_bgra):
-    height = physical_camera_image_2d_bgra.height
+def test_height(image_2d_bgra):
+    height = image_2d_bgra.height
 
     assert height is not None
     assert isinstance(height, int)
 
 
-@pytest.mark.physical_camera
-def test_width(physical_camera_image_2d_bgra):
-    width = physical_camera_image_2d_bgra.width
+def test_width(image_2d_bgra):
+    width = image_2d_bgra.width
 
     assert width is not None
     assert isinstance(width, int)

--- a/test/test_image_2d_rgba.py
+++ b/test/test_image_2d_rgba.py
@@ -1,11 +1,10 @@
 import pytest
 
 
-@pytest.mark.physical_camera
-def test_copy_data(physical_camera_image_2d_rgba):
+def test_copy_data(image_2d_rgba):
     import numpy as np
 
-    image = physical_camera_image_2d_rgba
+    image = image_2d_rgba
     rgba = image.copy_data()
     assert rgba is not None
     assert isinstance(rgba, np.ndarray)
@@ -13,45 +12,39 @@ def test_copy_data(physical_camera_image_2d_rgba):
     assert rgba.dtype == np.uint8
 
 
-@pytest.mark.physical_camera
-def test_save_path(physical_camera_image_2d_rgba):
+def test_save_path(image_2d_rgba):
     from pathlib import Path
 
-    physical_camera_image_2d_rgba.save(Path("some_file.png"))
+    image_2d_rgba.save(Path("some_file.png"))
 
 
-@pytest.mark.physical_camera
-def test_save_string(physical_camera_image_2d_rgba):
-    physical_camera_image_2d_rgba.save("some_file.png")
+def test_save_string(image_2d_rgba):
+    image_2d_rgba.save("some_file.png")
 
 
-@pytest.mark.physical_camera
-def test_to_array_context_manager(physical_camera_frame_2d):
-    with physical_camera_frame_2d.image_rgba() as image_2d:
+def test_to_array_context_manager(frame_2d):
+    with frame_2d.image_rgba() as image_2d:
         image_2d.copy_data()
     with pytest.raises(RuntimeError):
         image_2d.copy_data()
 
 
-@pytest.mark.physical_camera
-def test_save_context_manager(physical_camera_frame_2d):
-    with physical_camera_frame_2d.image_rgba() as image_2d:
+def test_save_context_manager(frame_2d):
+    with frame_2d.image_rgba() as image_2d:
         image_2d.save("some_file.png")
     with pytest.raises(RuntimeError):
         image_2d.save("some_file.png")
 
 
-@pytest.mark.physical_camera
-def test_height(physical_camera_image_2d_rgba):
-    height = physical_camera_image_2d_rgba.height
+def test_height(image_2d_rgba):
+    height = image_2d_rgba.height
 
     assert height is not None
     assert isinstance(height, int)
 
 
-@pytest.mark.physical_camera
-def test_width(physical_camera_image_2d_rgba):
-    width = physical_camera_image_2d_rgba.width
+def test_width(image_2d_rgba):
+    width = image_2d_rgba.width
 
     assert width is not None
     assert isinstance(width, int)


### PR DESCRIPTION
Previously all unit-tests that depend on 2D capture were marked with `@pytest.mark.physical_camera` because at some point in the past 2D captures did not work with file cameras. Such tests are not run in the CI because the CI does not have access to real cameras.  The intended procedure was that developers would run pytest with `-m physical_camera` before making a PR. However this is a vulnerable system because:

- Developers may forget or not know that they should do this.
- Even if they do this, they are unlikely to do it on all supported platforms. So it was possible to merge changes to 2D capture API that for example does not work on Python 3.6.

In the latest SDK release it is not a problem to do 2D captures with file cameras. Thus we can close this pitfall by making all the 2D capture API tests use a file camera instead, so that they are run in the CI on all supported platforms.