### PR TITLE
Capture: Unlock GIL during capture to allow async

### DIFF
--- a/samples/sample_capture_async.py
+++ b/samples/sample_capture_async.py
@@ -1,0 +1,65 @@
+"""Sample demonstrating how to capture with multiple cameras at the same time."""
+import concurrent.futures
+import datetime
+import time
+
+import zivid
+
+
+def _capture_sync(cameras: list[zivid.Camera]) -> list[zivid.Frame]:
+    return [
+        camera.capture(
+            zivid.Settings(
+                acquisitions=[
+                    zivid.Settings.Acquisition(
+                        exposure_time=datetime.timedelta(microseconds=100000)
+                    )
+                ]
+            )
+        )
+        for camera in cameras
+    ]
+
+
+def _capture_async(cameras: list[zivid.Camera]) -> list[zivid.Frame]:
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        futures = [
+            executor.submit(
+                camera.capture,
+                zivid.Settings(
+                    acquisitions=[
+                        zivid.Settings.Acquisition(
+                            exposure_time=datetime.timedelta(microseconds=100000)
+                        )
+                    ]
+                ),
+            )
+            for camera in cameras
+        ]
+
+        return [future.result() for future in futures]
+
+
+def _main():
+    app = zivid.Application()
+    cameras = app.cameras()
+    for camera in cameras:
+        camera.connect()
+
+    start = time.monotonic()
+    _capture_async(cameras)
+    end = time.monotonic()
+    print(
+        f"Time taken to capture asynchronously from {len(cameras)} camera(s): {end-start} seconds"
+    )
+
+    start = time.monotonic()
+    _capture_sync(cameras)
+    end = time.monotonic()
+    print(
+        f"Time taken to capture synchronously from {len(cameras)} camera(s): {end-start} seconds"
+    )
+
+
+if __name__ == "__main__":
+    _main()

--- a/src/include/ZividPython/Releasable.h
+++ b/src/include/ZividPython/Releasable.h
@@ -2,12 +2,19 @@
 
 #include <memory>
 #include <optional>
+#include <pybind11/pybind11.h>
 #include <stdexcept>
+
+#define WITH_GIL_UNLOCKED(...)                                                                                         \
+    [&, this] {                                                                                                        \
+        pybind11::gil_scoped_release gilLock;                                                                          \
+        return __VA_ARGS__;                                                                                            \
+    }()
 
 #define ZIVID_PYTHON_FORWARD_0_ARGS_TEMPLATE_1_ARG_WRAP_RETURN(returnType, functionName, returnTypeTypename)           \
     auto functionName()                                                                                                \
     {                                                                                                                  \
-        return returnType{ impl().functionName<returnTypeTypename>() };                                                \
+        return returnType{ WITH_GIL_UNLOCKED(impl().functionName<returnTypeTypename>()) };                             \
     }
 
 #define ZIVID_PYTHON_FORWARD_0_ARGS(functionName)                                                                      \
@@ -19,7 +26,7 @@
 #define ZIVID_PYTHON_FORWARD_0_ARGS_TEMPLATE_1_ARG(functionName, returnTypeTypename)                                   \
     decltype(auto) functionName()                                                                                      \
     {                                                                                                                  \
-        return impl().functionName<returnTypeTypename>();                                                              \
+        return WITH_GIL_UNLOCKED(impl().functionName<returnTypeTypename>());                                           \
     }
 
 #define ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(returnType, functionName)                                              \
@@ -31,7 +38,7 @@
 #define ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_CONTAINER_RETURN(container, returnType, functionName)                         \
     auto functionName()                                                                                                \
     {                                                                                                                  \
-        auto nativeContainer = impl().functionName();                                                                  \
+        auto nativeContainer = WITH_GIL_UNLOCKED(impl().functionName());                                               \
         container<returnType> returnContainer;                                                                         \
         returnContainer.reserve(nativeContainer.size());                                                               \
         std::transform(std::make_move_iterator(begin(nativeContainer)),                                                \
@@ -46,25 +53,25 @@
 #define ZIVID_PYTHON_FORWARD_1_ARGS(functionName, arg1Type, arg1Name)                                                  \
     decltype(auto) functionName(arg1Type arg1Name)                                                                     \
     {                                                                                                                  \
-        return impl().functionName(arg1Name);                                                                          \
+        return WITH_GIL_UNLOCKED(impl().functionName(arg1Name));                                                       \
     }
 
 #define ZIVID_PYTHON_FORWARD_1_ARGS_WRAP_RETURN(returnType, functionName, arg1Type, arg1Name)                          \
     auto functionName(arg1Type arg1Name)                                                                               \
     {                                                                                                                  \
-        return returnType{ impl().functionName(arg1Name) };                                                            \
+        return returnType{ WITH_GIL_UNLOCKED(impl().functionName(arg1Name)) };                                         \
     }
 
 #define ZIVID_PYTHON_FORWARD_2_ARGS(functionName, arg1Type, arg1Name, arg2Type, arg2Name)                              \
     decltype(auto) functionName(arg1Type arg1Name, arg2Type arg2Name)                                                  \
     {                                                                                                                  \
-        return impl().functionName(arg1Name, arg2Name);                                                                \
+        return WITH_GIL_UNLOCKED(impl().functionName(arg1Name, arg2Name));                                             \
     }
 
 #define ZIVID_PYTHON_FORWARD_2_ARGS_WRAP_RETURN(returnType, functionName, arg1Type, arg1Name, arg2Type, arg2Name)      \
     auto functionName(arg1Type arg1Name, arg2Type arg2Name)                                                            \
     {                                                                                                                  \
-        return returnType{ impl().functionName(arg1Name, arg2Name) };                                                  \
+        return returnType{ WITH_GIL_UNLOCKED(impl().functionName(arg1Name, arg2Name)) };                               \
     }
 
 #define ZIVID_PYTHON_ADD_COMPARE(op)                                                                                   \


### PR DESCRIPTION
This unlocks GIL during captures so they can be executed in parallel. This also adds a sample to show how to execute captures in parallel.

Implements ZIVID-6981