### PR TITLE
Update file camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ Instead of manually adjusting settings, the Capture Assistant may be used to fin
 
 ### Using camera emulation
 
-If you do not have a camera, you can use the `FileCameraZividOne.zfc` file in [ZividSampleData2.zip][zivid-download-sampledata-url] to emulate a camera.
+If you do not have a camera, you can use the `FileCameraZivid2M70.zfc` file in the [Sample Data][zivid-download-sampledata-url] to emulate a camera.
 
     import zivid
     app = zivid.Application()
-    camera = app.create_file_camera("path/to/FileCameraZividOne.zfc")
+    camera = app.create_file_camera("path/to/FileCameraZivid2M70.zfc")
     settings = zivid.Settings(acquisitions=[zivid.Settings.Acquisition()])
     frame = camera.capture(settings)
     frame.save("result.zdf")
@@ -187,7 +187,7 @@ Please visit [Zivid Knowledge Base][zivid-knowledge-base-url] for general inform
 [zivid-knowledge-base-url]: http://support.zivid.com
 [zivid-software-installation-url]: https://support.zivid.com/latest/getting-started/software-installation.html
 [zivid-download-software-url]: https://www.zivid.com/downloads
-[zivid-download-sampledata-url]: https://www.zivid.com/software/ZividSampleData2.zip
+[zivid-download-sampledata-url]: https://support.zivid.com/en/latest/api-reference/samples/sample-data.html
 [zivid-software-url]: http://www.zivid.com/software
 [zivid-python-releases-url]: https://pypi.org/project/zivid/#history
 [zivid-studio-guide-url]: https://support.zivid.com/en/latest/getting-started/studio-guide.html

--- a/samples/sample_capture_from_file.py
+++ b/samples/sample_capture_from_file.py
@@ -4,7 +4,7 @@ from zivid import Application, Settings
 
 def _main():
     app = Application()
-    camera = app.create_file_camera("FileCameraZividOne.zfc")
+    camera = app.create_file_camera("FileCameraZivid2M70.zfc")
 
     settings = Settings(acquisitions=[Settings.Acquisition()])
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -26,7 +26,7 @@ def application_fixture():
 
 @pytest.fixture(name="file_camera_file", scope="module")
 def file_camera_file_fixture():
-    return _testdata_dir() / "FileCameraZividOne.zfc"
+    return _testdata_dir() / "FileCameraZivid2M70.zfc"
 
 
 @pytest.fixture(name="physical_camera", scope="module")

--- a/test/test_camera_info.py
+++ b/test/test_camera_info.py
@@ -4,7 +4,7 @@ def test_revision(file_camera_info):
     revision = file_camera_info.revision
     assert revision is not None
     assert isinstance(revision, zivid.CameraInfo.Revision)
-    assert revision == zivid.CameraInfo.Revision(0, 0)
+    assert revision == zivid.CameraInfo.Revision(0, 2)
 
 
 def test_firmware_version(file_camera_info):

--- a/test/test_data/FileCameraZivid2M70.zfc
+++ b/test/test_data/FileCameraZivid2M70.zfc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a95f0158f1d4f0a3e9cb11d71a5982529d13387f4a9a48854af2e4466474d677
+size 29135449

--- a/test/test_data/FileCameraZividOne.zfc
+++ b/test/test_data/FileCameraZividOne.zfc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:406c52238dd55105e045469e0d716f0cda3d67d9993cab58fe583a09282eff10
-size 38227272

--- a/test/test_region_of_interest.py
+++ b/test/test_region_of_interest.py
@@ -4,8 +4,8 @@ import numpy as np
 def test_region_of_interest_depth(file_camera):
     import zivid
 
-    z_min = 600.0
-    z_max = 625.0
+    z_min = 650.0
+    z_max = 800.0
 
     # Make sure default capture has points outside the range we want
     settings = zivid.Settings(acquisitions=[zivid.Settings.Acquisition()])


### PR DESCRIPTION
The file `FileCameraZividOne.zfc` is on an old format that will no longer be supported in the upcoming SDK 2.10. It is also no longer included in the official sample data zip.

This commit updates the tests and instructions to use the new `FileCameraZivid2M70.zfc` instead.