### PR TITLE
Fix `docker_generate_datamodels.sh`

### DIFF
--- a/continuous-integration/code-generation/generate_datamodels.sh
+++ b/continuous-integration/code-generation/generate_datamodels.sh
@@ -8,6 +8,11 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$(realpath "$SCRIPT_DIR/../..")
 
+if [ -z "$VIRTUAL_ENV" ]; then
+    source $SCRIPT_DIR/../linux/venv.sh || exit $?
+    activate_venv || exit $?
+fi
+
 python3 -m pip install --requirement "$SCRIPT_DIR/../python-requirements/lint.txt" || exit $?
 
 python3 "$ROOT_DIR/continuous-integration/code-generation/datamodel_frontend_generator.py" \


### PR DESCRIPTION
The script `docker_generate_datamodels.sh` has been broken since we started using virtual envs in the CI scripts a few weeks ago. Since `build.sh` installs `zivid` in a venv, `generate_datamodels.sh` would fail to find the package since it was not running in the same venv. This commit fixes this by making `generate_datamodels.sh` activate the CI venv set up by the previous steps. We only do this if there is no venv currently activated, because we still want developers to be able to run `generate_datamodels.sh` directly with their own venv.