### PR TITLE
Add support for overloads of calibration.intrinsics

### DIFF
--- a/modules/zivid/experimental/calibration.py
+++ b/modules/zivid/experimental/calibration.py
@@ -3,20 +3,50 @@
 import _zivid
 from zivid.calibration import DetectionResult
 from zivid.camera_intrinsics import _to_camera_intrinsics
+from zivid.settings import Settings, _to_internal_settings
+from zivid.settings_2d import Settings2D, _to_internal_settings2d
 
 
-def intrinsics(camera):
-    """Get intrinsic parameters of a given camera.
+def intrinsics(camera, settings=None):
+    """Get intrinsic parameters of a given camera and settings (3D or 2D).
+
+    These intrinsic parameters take into account the expected resolution of the point clouds captured
+    with the given settings. If settings are not provided, intrinsics appropriate for the camera's
+    default 3D capture settings is returned.
 
     Args:
         camera: A Camera instance
+        settings: Settings or Settings2D to be used to get correct intrinsics (optional)
 
     Returns:
         A CameraIntrinsics instance
+
+    Raises:
+        TypeError: If settings argument is not Settings or Settings2D
     """
-    return _to_camera_intrinsics(
-        _zivid.calibration.intrinsics(
-            camera._Camera__impl  # pylint: disable=protected-access
+    if settings is None:
+        return _to_camera_intrinsics(
+            _zivid.calibration.intrinsics(
+                camera._Camera__impl  # pylint: disable=protected-access
+            )
+        )
+    if isinstance(settings, Settings):
+        return _to_camera_intrinsics(
+            _zivid.calibration.intrinsics(
+                camera._Camera__impl,  # pylint: disable=protected-access
+                _to_internal_settings(settings),
+            )
+        )
+    if isinstance(settings, Settings2D):
+        return _to_camera_intrinsics(
+            _zivid.calibration.intrinsics(
+                camera._Camera__impl,  # pylint: disable=protected-access
+                _to_internal_settings2d(settings),
+            )
+        )
+    raise TypeError(
+        "Unsupported type for argument settings. Got {}, expected Settings or Settings2D.".format(
+            type(settings)
         )
     )
 

--- a/src/Calibration/Calibration.cpp
+++ b/src/Calibration/Calibration.cpp
@@ -18,9 +18,11 @@
 
 #include <vector>
 
+namespace py = pybind11;
+
 namespace ZividPython::Calibration
 {
-    void wrapAsSubmodule(pybind11::module &dest)
+    void wrapAsSubmodule(py::module &dest)
     {
         using namespace Zivid::Calibration;
 
@@ -40,10 +42,26 @@ namespace ZividPython::Calibration
             .def("calibrate_eye_in_hand", &Zivid::Calibration::calibrateEyeInHand)
             .def("calibrate_eye_to_hand", &Zivid::Calibration::calibrateEyeToHand)
             .def("calibrate_multi_camera", &Zivid::Calibration::calibrateMultiCamera)
-            .def("intrinsics",
-                 [](ReleasableCamera &releasableCamera) {
-                     return Zivid::Experimental::Calibration::intrinsics(releasableCamera.impl());
-                 })
+            .def(
+                "intrinsics",
+                [](ReleasableCamera &releasableCamera) {
+                    return Zivid::Experimental::Calibration::intrinsics(releasableCamera.impl());
+                },
+                py::arg("camera"))
+            .def(
+                "intrinsics",
+                [](ReleasableCamera &releasableCamera, const Zivid::Settings &settings) {
+                    return Zivid::Experimental::Calibration::intrinsics(releasableCamera.impl(), settings);
+                },
+                py::arg("camera"),
+                py::arg("settings"))
+            .def(
+                "intrinsics",
+                [](ReleasableCamera &releasableCamera, const Zivid::Settings2D &settings_2d) {
+                    return Zivid::Experimental::Calibration::intrinsics(releasableCamera.impl(), settings_2d);
+                },
+                py::arg("camera"),
+                py::arg("settings_2d"))
             .def("estimate_intrinsics", [](ReleasableFrame &releasableFrame) {
                 return Zivid::Experimental::Calibration::estimateIntrinsics(releasableFrame.impl());
             });

--- a/test/calibration/test_intrinsics.py
+++ b/test/calibration/test_intrinsics.py
@@ -24,6 +24,26 @@ def test_intrinsics(file_camera):
     _check_camera_intrinsics(camera_intrinsics)
 
 
+def test_intrinsics_with_settings_2d(file_camera):
+    from zivid.experimental.calibration import intrinsics
+    from zivid.settings_2d import Settings2D
+
+    camera_intrinsics = intrinsics(
+        camera=file_camera, settings=Settings2D(acquisitions=[Settings2D.Acquisition()])
+    )
+    _check_camera_intrinsics(camera_intrinsics)
+
+
+def test_intrinsics_with_settings_3d(file_camera):
+    from zivid.experimental.calibration import intrinsics
+    from zivid.settings import Settings
+
+    camera_intrinsics = intrinsics(
+        camera=file_camera, settings=Settings(acquisitions=[Settings.Acquisition()])
+    )
+    _check_camera_intrinsics(camera_intrinsics)
+
+
 def test_estimate_intrinsics(frame):
     from zivid.experimental.calibration import estimate_intrinsics
 


### PR DESCRIPTION
SDK 2.10.0 introduces two overloads of the calibration.intrinsics API. One with settings and one with settings_2d. This commit adds support in the Python wrapper.