### PR TITLE
Add python support for presets API

### DIFF
--- a/modules/_zivid/__init__.py
+++ b/modules/_zivid/__init__.py
@@ -65,6 +65,7 @@ try:
         data_model,
         projection,
         ProjectedImage,
+        presets,
     )
 except ImportError as ex:
 

--- a/modules/zivid/__init__.py
+++ b/modules/zivid/__init__.py
@@ -7,6 +7,7 @@ __version__ = zivid._version.get_version(__name__)  # pylint: disable=protected-
 import zivid.firmware
 import zivid.capture_assistant
 import zivid.calibration
+import zivid.presets
 
 from zivid.application import Application
 from zivid.camera import Camera

--- a/modules/zivid/presets.py
+++ b/modules/zivid/presets.py
@@ -1,0 +1,136 @@
+"""Contains the Preset and Category classes."""
+import _zivid
+
+from zivid.settings import _to_settings
+from zivid.camera_info import CameraInfo, _to_internal_camera_info
+
+
+class Preset:
+    """3D settings preset.
+
+    Presets are pre-defined settings that are tuned for different camera models to perform optimally
+    under different conditions and use cases.
+
+    This class cannot be initialized directly by the end-user. Use the presets method on the
+    Category class to obtain a Preset instance.
+    """
+
+    def __init__(self, impl):
+        """Initialize Preset wrapper.
+
+        This constructor is only used internally, and should not be called by the end-user.
+
+        Args:
+            impl:   Reference to internal/back-end instance.
+
+        Raises:
+            TypeError: If argument does not match the expected internal class.
+        """
+        if not isinstance(impl, _zivid.presets.Preset):
+            raise TypeError(
+                "Unsupported type for argument impl. Got {}, expected {}".format(
+                    type(impl), _zivid.presets.Preset
+                )
+            )
+        self.__impl = impl
+
+    @property
+    def name(self):
+        """Get the name of the preset.
+
+        Returns:
+            The name of the preset.
+        """
+        return self.__impl.name()
+
+    @property
+    def settings(self):
+        """Get the settings of the preset.
+
+        The settings might change between different releases of the SDK. New presets might be added
+        and old ones might be removed. If having the exact same settings is desired, it is
+        recommended to save them to a YML file and load as needed.
+
+        Returns:
+                The settings of the preset.
+        """
+        return _to_settings(self.__impl.settings())
+
+    def __str__(self):
+        return str(self.__impl)
+
+
+class Category:
+    """Preset category.
+
+    This class cannot be initialized directly by the end-user. Use the categories function to
+    obtain a list of categories available for a camera.
+    """
+
+    def __init__(self, impl):
+        """Initialize Category wrapper.
+
+        This constructor is only used internally, and should not be called by the end-user.
+
+        Args:
+            impl:   Reference to internal/back-end instance.
+
+        Raises:
+            TypeError: If argument does not match the expected internal class.
+        """
+        if not isinstance(impl, _zivid.presets.Category):
+            raise TypeError(
+                "Unsupported type for argument impl. Got {}, expected {}".format(
+                    type(impl), _zivid.presets.Category
+                )
+            )
+        self.__impl = impl
+
+    @property
+    def name(self):
+        """Get the name of the category.
+
+        Returns:
+            The name of the category.
+        """
+        return self.__impl.name()
+
+    @property
+    def presets(self):
+        """Get the presets available in the category.
+
+        The settings might change between different releases of the SDK. New presets might be added
+        and old ones might be removed. If having the exact same settings is desired, it is
+        recommended to save them to a YML file and load as needed.
+
+        Returns:
+            The presets available in the category.
+        """
+        return [Preset(p) for p in self.__impl.presets()]
+
+    def __str__(self):
+        return str(self.__impl)
+
+
+def categories(model):
+    """Get available preset categories for the specified camera model.
+
+    A preset category contains a collection of presets optimized for one scenario or use case.
+
+    The settings might change between different releases of the SDK. New presets might be added
+    and old ones might be removed. If having the exact same settings is desired, it is recommended
+    to save them to a YML file and load as needed.
+
+    Args:
+        model: The model for the camera whose preset categories should be returned. This value can
+               be obtained from CameraInfo.model.
+
+    Returns:
+        The available categories for the specified camera model.
+    """
+    return [
+        Category(c)
+        for c in _zivid.presets.categories(
+            _to_internal_camera_info(CameraInfo(model=model)).model
+        )
+    ]

--- a/samples/sample_presets.py
+++ b/samples/sample_presets.py
@@ -1,0 +1,39 @@
+"""Presets sample."""
+from zivid import Application
+from zivid.presets import categories
+
+
+def _main():
+    app = Application()
+
+    with app.connect_camera() as camera:
+        available_categories = categories(camera.info.model)
+        print("The following preset categories are available:")
+        for index, category in enumerate(available_categories):
+            print("    {}: {}".format(index, category.name))
+        chosen_category = available_categories[
+            int(input("Choose a category (enter a number): "))
+        ]
+
+        print(
+            "The following presets are available in category '{}':".format(
+                chosen_category.name
+            )
+        )
+        for index, preset in enumerate(chosen_category.presets):
+            print("    {}: {}".format(index, preset.name))
+        chosen_preset = chosen_category.presets[
+            int(input("Choose a preset (enter a number): "))
+        ]
+
+        print("Capturing point cloud with preset '{}' ...".format(chosen_preset.name))
+        with camera.capture(chosen_preset.settings) as frame:
+            frame.save("result.zdf")
+
+        settings_file = chosen_preset.name + ".yml"
+        print("Saving settings to {}".format(settings_file))
+        chosen_preset.settings.save(settings_file)
+
+
+if __name__ == "__main__":
+    _main()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCES
     InfieldCorrection/InfieldCorrection.cpp
     NodeType.cpp
     Projection.cpp
+    Presets.cpp
     ReleasableArray2D.cpp
     ReleasableCamera.cpp
     ReleasableFrame.cpp

--- a/src/Presets.cpp
+++ b/src/Presets.cpp
@@ -1,0 +1,30 @@
+#include <ZividPython/Presets.h>
+#include <ZividPython/Wrappers.h>
+
+namespace ZividPython
+{
+
+    void wrapClass(pybind11::class_<Zivid::Presets::Preset> pyClass)
+    {
+        pyClass.def("name", &Zivid::Presets::Preset::name).def("settings", &Zivid::Presets::Preset::settings);
+    }
+
+    void wrapClass(pybind11::class_<Zivid::Presets::Category> pyClass)
+    {
+        pyClass.def("name", &Zivid::Presets::Category::name).def("presets", &Zivid::Presets::Category::presets);
+    }
+
+    namespace Presets
+    {
+        void wrapAsSubmodule(pybind11::module &dest)
+        {
+            using namespace Zivid::Presets;
+
+            ZIVID_PYTHON_WRAP_CLASS(dest, Preset);
+            ZIVID_PYTHON_WRAP_CLASS(dest, Category);
+
+            dest.def("categories", &categories);
+        }
+    } // namespace Presets
+
+} // namespace ZividPython

--- a/src/Wrapper.cpp
+++ b/src/Wrapper.cpp
@@ -9,6 +9,7 @@
 #include <ZividPython/Firmware.h>
 #include <ZividPython/InfieldCorrection/InfieldCorrection.h>
 #include <ZividPython/Matrix4x4.h>
+#include <ZividPython/Presets.h>
 #include <ZividPython/Projection.h>
 #include <ZividPython/ReleasableArray2D.h>
 #include <ZividPython/ReleasableCamera.h>
@@ -65,4 +66,5 @@ ZIVID_PYTHON_MODULE // NOLINT
     ZIVID_PYTHON_WRAP_NAMESPACE_AS_SUBMODULE(module, CaptureAssistant);
     ZIVID_PYTHON_WRAP_NAMESPACE_AS_SUBMODULE(module, InfieldCorrection);
     ZIVID_PYTHON_WRAP_NAMESPACE_AS_SUBMODULE(module, Projection);
+    ZIVID_PYTHON_WRAP_NAMESPACE_AS_SUBMODULE(module, Presets);
 }

--- a/src/include/ZividPython/Presets.h
+++ b/src/include/ZividPython/Presets.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Zivid/Presets.h>
+#include <ZividPython/Wrappers.h>
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+
+namespace ZividPython
+{
+    void wrapClass(pybind11::class_<Zivid::Presets::Preset> pyClass);
+
+    void wrapClass(pybind11::class_<Zivid::Presets::Category> pyClass);
+
+    namespace Presets
+    {
+        void wrapAsSubmodule(pybind11::module &dest);
+    } // namespace Presets
+} // namespace ZividPython

--- a/test/test_presets.py
+++ b/test/test_presets.py
@@ -1,0 +1,14 @@
+def test_presets(application):  # pylint: disable=unused-argument
+    import zivid
+
+    for model in zivid.CameraInfo.Model.valid_values():
+        categories = zivid.presets.categories(model)
+        assert categories
+        for category in categories:
+            assert isinstance(category, zivid.presets.Category)
+            assert category.name != ""
+            assert category.presets
+            for preset in category.presets:
+                assert isinstance(preset, zivid.presets.Preset)
+                assert preset.name != ""
+                assert isinstance(preset.settings, zivid.Settings)


### PR DESCRIPTION
The presets API added in Zivid SDK 2.9 allows the user to obtain settings presets that are fine tuned for each camera model for a number of different use-cases.

See samples/sample_presets.py for an example of how to use it.