### PR TITLE
Add new in-field correction functions

### DIFF
--- a/src/InfieldCorrection/InfieldCorrection.cpp
+++ b/src/InfieldCorrection/InfieldCorrection.cpp
@@ -23,6 +23,12 @@ namespace ZividPython::InfieldCorrection
 
         dest.def("detect_feature_points_infield",
                  [](ReleasableCamera &releasableCamera) { return detectFeaturePoints(releasableCamera.impl()); })
+            .def("detect_feature_points_infield",
+                 [](const ReleasableFrame &releasableFrame) { return detectFeaturePoints(releasableFrame.impl()); })
+            .def("capture_calibration_board",
+                 [](ReleasableCamera &releasableCamera) {
+                     return ReleasableFrame{ captureCalibrationBoard(releasableCamera.impl()) };
+                 })
             .def("verify_camera", &verifyCamera)
             .def("compute_camera_correction", &computeCameraCorrection)
             .def("write_camera_correction",


### PR DESCRIPTION
This commit exposes two new functions from the experimental in-field correction C++ API:

1. A new overload of detect_feature_points that takes a Frame as an argument. The existing python function has been updated to support both a Camera (the previously supported argument type) and a Frame.
2. capture_calibration_board, which captures a calibration board with the correct settings and returns the frame.

Fixes ZIVID-6764