### PR TITLE
CI: disable GPG check for OneAPI repo on Fedora

### DIFF
--- a/continuous-integration/linux/platform-dependent/common.sh
+++ b/continuous-integration/linux/platform-dependent/common.sh
@@ -18,12 +18,13 @@ function ubuntu_install_opencl_cpu_runtime {
 }
 
 function fedora_install_opencl_cpu_runtime {
+    # TODO: re-enable gpgcheck once Intel have fixed their packages
     tee > /etc/yum.repos.d/oneAPI.repo << EOF
 [oneAPI]
 name=Intel® oneAPI repository
 baseurl=https://yum.repos.intel.com/oneapi
 enabled=1
-gpgcheck=1
+gpgcheck=0
 repo_gpgcheck=1
 gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
 EOF


### PR DESCRIPTION
It seems like Intel have used the wrong key when building the their OneAPI packages. To fix CI we have to disable the GPG check until they have fixed their packages.
