### PR TITLE
Fix unit-test fixture teardown

### DIFF
--- a/test/calibration/test_hand_eye.py
+++ b/test/calibration/test_hand_eye.py
@@ -95,7 +95,7 @@ def test_eyetohand_calibration_save_load(handeye_eth_frames, handeye_eth_poses):
         ]
     )
 
-    with tempfile.TemporaryDirectory() as tmpdir, zivid.Application() as _:
+    with tempfile.TemporaryDirectory() as tmpdir:
         transform = handeye_output.transform()
         file_path = Path(tmpdir) / "matrix.yml"
         zivid.Matrix4x4(transform).save(file_path)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -52,7 +52,7 @@ def default_settings_2d_fixture():
 
 
 @pytest.fixture(name="frame_file", scope="module")
-def frame_file_fixture(application, file_camera, default_settings):
+def frame_file_fixture(file_camera, default_settings):
     with tempfile.TemporaryDirectory() as temp_dir:
         file_path = Path(temp_dir) / "test_frame.zdf"
         with file_camera.capture(default_settings) as frame:
@@ -68,11 +68,14 @@ def checkerboard_frames_fixture(application):
     ]
     assert len(frames) == 3
     yield frames
+    for frame in frames:
+        frame.release()
 
 
 @pytest.fixture(name="calibration_board_frame", scope="module")
 def calibration_board_frame_fixture(application):
-    yield zivid.Frame(_testdata_dir() / "ZVD-CB01.zdf")
+    with zivid.Frame(_testdata_dir() / "ZVD-CB01.zdf") as frame:
+        yield frame
 
 
 @pytest.fixture(name="multicamera_transforms", scope="module")
@@ -89,6 +92,8 @@ def handeye_eth_frames_fixture(application):
     path = _testdata_dir() / "handeye" / "eth"
     frames = [zivid.Frame(file_path) for file_path in sorted(path.glob("*.zdf"))]
     yield frames
+    for frame in frames:
+        frame.release()
 
 
 @pytest.fixture(name="frame", scope="function")


### PR DESCRIPTION
We noticed that unit-tests were failing when run with SDK 2.11. It turns out that we were not tearing down objects in the right order, and SDK 2.11 is less tolerance to such things.

This commit does two things to fix the unit-tests:
- Make sure that all fixtures that yield frames end up releasing those frames on teardown.
- Fix a test that created a new Application inside its code while also indirectly depending on the "application" fixture.