### PR TITLE
Add Ubuntu 23.10 to CI test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
               --volume $PWD:/host \
               --workdir /host/continuous-integration/linux \
               --env "PYTHONDONTWRITEBYTECODE=1" \
-              ubuntu:23.04  \
+              ubuntu:23.10  \
               bash -c "./setup.sh && ./build.sh && ./lint.sh"
       - name: Notify Teams
         if: ${{ failure() && github.ref == 'refs/heads/master' }}
@@ -103,6 +103,7 @@ jobs:
           - ubuntu:20.04
           - ubuntu:22.04
           - ubuntu:23.04
+          - ubuntu:23.10
           - fedora:35
           - fedora:36
           - fedora:37

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Please visit [Zivid Knowledge Base][zivid-knowledge-base-url] for general inform
 
 | Operating System | Python version            |
 | :--------------- | :------------------------ |
+| Ubuntu 23.10     | 3.11                      |
 | Ubuntu 23.04     | 3.11                      |
 | Ubuntu 22.04     | 3.10                      |
 | Ubuntu 20.04     | 3.8                       |

--- a/continuous-integration/linux/platform-dependent/ubuntu-23.10/setup.sh
+++ b/continuous-integration/linux/platform-dependent/ubuntu-23.10/setup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+export DEBIAN_FRONTEND=noninteractive
+SCRIPT_DIR="$(realpath $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) )"
+
+function apt-yes {
+    apt-get --assume-yes "$@"
+}
+
+apt-yes update || exit $?
+apt-yes dist-upgrade || exit $?
+
+apt-yes install \
+    clinfo \
+    g++ \
+    jq \
+    python3-dev \
+    python3-venv \
+    python3-pip \
+    wget \
+    || exit $?
+
+update-alternatives --install /usr/bin/python python /usr/bin/python3 0 || exit $?
+update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 0 || exit $?
+
+source $(realpath $SCRIPT_DIR/../common.sh) || exit $?
+ubuntu_install_opencl_cpu_runtime || exit $?
+
+function install_www_deb {
+    TMP_DIR=$(mktemp --tmpdir --directory zivid-python-install-www-deb-XXXX) || exit $?
+    pushd $TMP_DIR || exit $?
+    wget -nv "$@" || exit $?
+    apt-yes install --fix-broken ./*deb || exit $?
+    popd || exit $?
+    rm -r $TMP_DIR || exit $?
+}
+
+install_www_deb "https://downloads.zivid.com/sdk/releases/${ZIVID_SDK_EXACT_VERSION}/u22/zivid-telicam-driver_${ZIVID_TELICAM_EXACT_VERSION}_amd64.deb" || exit $?
+install_www_deb "https://downloads.zivid.com/sdk/releases/${ZIVID_SDK_EXACT_VERSION}/u22/zivid_${ZIVID_SDK_EXACT_VERSION}_amd64.deb" || exit $?


### PR DESCRIPTION
We also make the linting job use this image, since we want that job to always use the latest supported Ubuntu.