### PR TITLE
Remove some code duplication 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ env
 __pycache__
 *.swp
 *.swo
+*.egg-info
+.cache

--- a/src/ReleasableArray2D.cpp
+++ b/src/ReleasableArray2D.cpp
@@ -1,7 +1,8 @@
 #include <ZividPython/ReleasableArray2D.h>
-
-#include <Zivid/PointCloud.h>
 #include <ZividPython/ReleasablePointCloud.h>
+
+#include <Zivid/Color.h>
+#include <Zivid/PointCloud.h>
 
 #include <pybind11/pybind11.h>
 
@@ -50,6 +51,18 @@ namespace
         return std::make_unique<ZividPython::ReleasableArray2D<NativeType>>(pointCloud.impl().copyData<NativeType>());
     }
 
+    template<typename NativeType>
+    void wrapImageClass(pybind11::class_<ZividPython::ReleasableArray2D<NativeType>> pyClass)
+    {
+        using WrapperType = uint8_t;
+        static_assert(std::is_same_v<WrapperType, decltype(NativeType::r)>);
+        static_assert(std::is_same_v<WrapperType, decltype(NativeType::g)>);
+        static_assert(std::is_same_v<WrapperType, decltype(NativeType::b)>);
+        static_assert(std::is_same_v<WrapperType, decltype(NativeType::a)>);
+
+        pyClass.def(py::init<>(&pointCloudDataCopier<NativeType>))
+            .def_buffer(pointCloudDataBuffer<NativeType, WrapperType, 4>);
+    }
 } // namespace
 
 namespace ZividPython
@@ -66,28 +79,12 @@ namespace ZividPython
 
     void wrapClass(pybind11::class_<ReleasableArray2D<Zivid::ColorRGBA>> pyClass)
     {
-        using WrapperType = uint8_t;
-        using NativeType = Zivid::ColorRGBA;
-        static_assert(std::is_same_v<WrapperType, decltype(NativeType::r)>);
-        static_assert(std::is_same_v<WrapperType, decltype(NativeType::g)>);
-        static_assert(std::is_same_v<WrapperType, decltype(NativeType::b)>);
-        static_assert(std::is_same_v<WrapperType, decltype(NativeType::a)>);
-
-        pyClass.def(py::init<>(&pointCloudDataCopier<NativeType>))
-            .def_buffer(pointCloudDataBuffer<NativeType, WrapperType, 4>);
+        wrapImageClass<Zivid::ColorRGBA>(pyClass);
     }
 
     void wrapClass(pybind11::class_<ReleasableArray2D<Zivid::ColorBGRA>> pyClass)
     {
-        using WrapperType = uint8_t;
-        using NativeType = Zivid::ColorBGRA;
-        static_assert(std::is_same_v<WrapperType, decltype(NativeType::b)>);
-        static_assert(std::is_same_v<WrapperType, decltype(NativeType::g)>);
-        static_assert(std::is_same_v<WrapperType, decltype(NativeType::r)>);
-        static_assert(std::is_same_v<WrapperType, decltype(NativeType::a)>);
-
-        pyClass.def(py::init<>(&pointCloudDataCopier<NativeType>))
-            .def_buffer(pointCloudDataBuffer<NativeType, WrapperType, 4>);
+        wrapImageClass<Zivid::ColorBGRA>(pyClass);
     }
 
     void wrapClass(pybind11::class_<ReleasableArray2D<Zivid::NormalXYZ>> pyClass)

--- a/src/ReleasableImage.cpp
+++ b/src/ReleasableImage.cpp
@@ -1,15 +1,18 @@
 #include <ZividPython/ReleasableImage.h>
 
+#include <Zivid/Color.h>
+
+#include <pybind11/buffer_info.h>
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
 namespace
 {
-    py::buffer_info imageRGBADataBuffer(ZividPython::ReleasableImageRGBA &image)
+    template<typename ImageType, typename NativeType>
+    py::buffer_info imageDataBuffer(ImageType &image)
     {
         using WrapperType = uint8_t;
-        using NativeType = Zivid::ColorRGBA;
 
         constexpr py::ssize_t dim = 3;
         constexpr py::ssize_t depth = 4;
@@ -33,31 +36,14 @@ namespace
                                 { dataSize * width * depth, dataSize * depth, dataSize } };
     }
 
+    py::buffer_info imageRGBADataBuffer(ZividPython::ReleasableImageRGBA &image)
+    {
+        return imageDataBuffer<ZividPython::ReleasableImageRGBA, Zivid::ColorRGBA>(image);
+    }
+
     py::buffer_info imageBGRADataBuffer(ZividPython::ReleasableImageBGRA &image)
     {
-        using WrapperType = uint8_t;
-        using NativeType = Zivid::ColorBGRA;
-
-        constexpr py::ssize_t dim = 3;
-        constexpr py::ssize_t depth = 4;
-        constexpr py::ssize_t dataSize = sizeof(WrapperType);
-
-        static_assert(dataSize * depth == sizeof(NativeType));
-        static_assert(std::is_same_v<WrapperType, decltype(NativeType::b)>);
-        static_assert(std::is_same_v<WrapperType, decltype(NativeType::g)>);
-        static_assert(std::is_same_v<WrapperType, decltype(NativeType::r)>);
-        static_assert(std::is_same_v<WrapperType, decltype(NativeType::a)>);
-
-        auto *dataPtr = static_cast<void *>(const_cast<NativeType *>(image.impl().data()));
-        const auto height = static_cast<py::ssize_t>(image.impl().height());
-        const auto width = static_cast<py::ssize_t>(image.impl().width());
-
-        return py::buffer_info{ dataPtr,
-                                dataSize,
-                                py::format_descriptor<WrapperType>::format(),
-                                dim,
-                                { height, width, depth },
-                                { dataSize * width * depth, dataSize * depth, dataSize } };
+        return imageDataBuffer<ZividPython::ReleasableImageBGRA, Zivid::ColorBGRA>(image);
     }
 } // namespace
 

--- a/src/include/ZividPython/ReleasableArray2D.h
+++ b/src/include/ZividPython/ReleasableArray2D.h
@@ -1,8 +1,10 @@
 #pragma once
 
-#include <Zivid/PointCloud.h>
 #include <ZividPython/Releasable.h>
 #include <ZividPython/Wrappers.h>
+
+#include <Zivid/Color.h>
+#include <Zivid/PointCloud.h>
 
 namespace ZividPython
 {


### PR DESCRIPTION
Removes code duplication in array2d and image class wrappers for Zivid::ColorRGBA and Zivid::ColorBGRA pixel formats. This helps when we add new pixel formats, for example, Zivid::ColorSRGB.