### PR TITLE
Fix unit test early Application teardown

### DIFF
--- a/test/calibration/test_multi_camera.py
+++ b/test/calibration/test_multi_camera.py
@@ -70,7 +70,7 @@ def test_multicamera_calibration_save_load(checkerboard_frames):
         ]
     )
 
-    with tempfile.TemporaryDirectory() as tmpdir, zivid.Application() as _:
+    with tempfile.TemporaryDirectory() as tmpdir:
         file_path = Path(tmpdir) / "matrix.yml"
         for transform in multicamera_output.transforms():
             zivid.Matrix4x4(transform).save(file_path)


### PR DESCRIPTION
Commit 3a2f7658 fixed several issues with object lifetimes in the unit tests. However, one case was missed where a test depends on the application fixture but also creates its own Application instance. This caused an error when a new test was added that ran after the faulty test.