### PR TITLE
CI - Update actions that use Node.js 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: false
       - name: Build and lint
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: false
       - name: Create source distribution
@@ -45,7 +45,7 @@ jobs:
               ubuntu:20.04 \
               bash -c "./setup.sh && ./create-source-distribution.sh"
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: source-distribution
           path: dist/zivid*.tar.gz
@@ -63,11 +63,11 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: false
       - name: Set up Python ${{matrix.python-version}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python-version}}
       - name: Setup
@@ -79,7 +79,7 @@ jobs:
           CC: 'cl.exe'
         run: python continuous-integration\windows\create_binary_distribution.py
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bdist-win-python${{matrix.python-version}}
           path: dist/zivid*.whl
@@ -108,11 +108,11 @@ jobs:
           - fedora:38
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: source-distribution
           path: dist
@@ -138,16 +138,16 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bdist-win-python${{matrix.python-version}}
           path: dist
       - name: Set up Python ${{matrix.python-version}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python-version}}
       - name: Setup
@@ -167,11 +167,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: false
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Collect and check
@@ -183,7 +183,7 @@ jobs:
               ubuntu:20.04 \
               bash -c "./collect-and-check-artifacts.sh"
       - name: Upload all as single artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: distributions_all
           path: distribution/


### PR DESCRIPTION
Following Node.js 16 actions are deprecated: `actions/checkout@v3`, `actions/upload-artifact@v3`, `action-download-artifact@v3`, `actions/setup-python@v4` -
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Update the actions to use the latest version.