### PR TITLE
Update docstring for InfieldCorrectionInput

### DIFF
--- a/modules/zivid/experimental/calibration.py
+++ b/modules/zivid/experimental/calibration.py
@@ -302,7 +302,7 @@ class InfieldCorrectionInput:
         """Construct an InfieldCorrectionInput instance.
 
         Input data should be captured by calling the version of detect_feature_points that
-        takes a Camera argument.
+        takes a Camera or Frame argument.
 
         Args:
             detection_result: A DetectionResult instance


### PR DESCRIPTION
Commit 066edbae updated detect_feature_points to support giving either a Camera or a Frame as input. This left the docstring for InfieldCorrectionInput, which references the "version of detect_feature_points that takes a Camera argument" outdated.

This commit updates the wording to say "Camera or Frame".