### PR TITLE
Add new non-experimental calibration board detection functions

### DIFF
--- a/modules/zivid/_calibration/detector.py
+++ b/modules/zivid/_calibration/detector.py
@@ -4,6 +4,8 @@ This module should not be imported directly by end-user, but rather accessed thr
 the zivid.calibration module.
 """
 import _zivid
+from zivid.camera import Camera
+from zivid.frame import Frame
 from zivid._calibration.pose import Pose
 
 
@@ -79,5 +81,75 @@ def detect_feature_points(point_cloud):
     return DetectionResult(
         _zivid.calibration.detect_feature_points(
             point_cloud._PointCloud__impl  # pylint: disable=protected-access
+        )
+    )
+
+
+def detect_calibration_board(source):
+    """
+    Detect feature points from a calibration board in a frame or using a given camera.
+
+    If a camera is used, this function will perform a relatively slow but high-quality point cloud
+    capture with the camera. This function is necessary for applications that require very
+    high-accuracy DetectionResult, such as in-field verification/correction.
+
+    The functionality is to be exclusively used in combination with Zivid verified calibration boards.
+    For further information please visit https://support.zivid.com.
+
+    Args:
+        source: A frame containing an image of a calibration board or a camera pointed at
+            a calibration board
+
+    Raises:
+        TypeError: If source is not of type Camera or Frame
+
+    Returns:
+        A DetectionResult instance
+    """
+
+    if isinstance(source, Camera):
+        return DetectionResult(
+            _zivid.calibration.detect_calibration_board(
+                source._Camera__impl  # pylint: disable=protected-access
+            )
+        )
+    if isinstance(source, Frame):
+        return DetectionResult(
+            _zivid.calibration.detect_calibration_board(
+                source._Frame__impl  # pylint: disable=protected-access
+            )
+        )
+    raise TypeError(
+        "Unsupported type for argument source. Got {}, expected one of {}".format(
+            type(source),
+            (Camera, Frame),
+        )
+    )
+
+
+def capture_calibration_board(camera):
+    """
+    Capture a calibration board with the given camera.
+
+    The functionality is to be exclusively used in combination with Zivid verified calibration boards.
+    For further information please visit https://support.zivid.com.
+
+    This function will perform a relatively slow but high-quality point cloud capture with the
+    given camera. This function is necessary for applications that require very high-accuracy
+    captures, such as in-field verification/correction.
+
+    The Frame that is returned from this function may be used as input to `detect_calibration_board`.
+    You may also use `detect_calibration_board` directly, which will invoke this function under the
+    hood and yield a DetectionResult.
+
+    Args:
+        camera: a Camera pointed at a calibration board
+
+    Returns:
+        A Frame
+    """
+    return Frame(
+        _zivid.calibration.capture_calibration_board(
+            camera._Camera__impl  # pylint: disable=protected-access
         )
     )

--- a/modules/zivid/calibration.py
+++ b/modules/zivid/calibration.py
@@ -1,6 +1,11 @@
 """Module for calibration features, such as HandEye and MultiCamera."""
 # pylint: disable=unused-import
-from zivid._calibration.detector import DetectionResult, detect_feature_points
+from zivid._calibration.detector import (
+    DetectionResult,
+    detect_feature_points,
+    detect_calibration_board,
+    capture_calibration_board,
+)
 from zivid._calibration.hand_eye import (
     HandEyeInput,
     HandEyeResidual,

--- a/src/Calibration/Calibration.cpp
+++ b/src/Calibration/Calibration.cpp
@@ -39,6 +39,18 @@ namespace ZividPython::Calibration
                  [](const ReleasablePointCloud &releasablePointCloud) {
                      return Zivid::Calibration::detectFeaturePoints(releasablePointCloud.impl());
                  })
+            .def("detect_calibration_board",
+                 [](ReleasableCamera &releasableCamera) {
+                     return Zivid::Calibration::detectCalibrationBoard(releasableCamera.impl());
+                 })
+            .def("detect_calibration_board",
+                 [](ReleasableFrame &releasableFrame) {
+                     return Zivid::Calibration::detectCalibrationBoard(releasableFrame.impl());
+                 })
+            .def("capture_calibration_board",
+                 [](ReleasableCamera &releasableCamera) {
+                     return ReleasableFrame{ Zivid::Calibration::captureCalibrationBoard(releasableCamera.impl()) };
+                 })
             .def("calibrate_eye_in_hand", &Zivid::Calibration::calibrateEyeInHand)
             .def("calibrate_eye_to_hand", &Zivid::Calibration::calibrateEyeToHand)
             .def("calibrate_multi_camera", &Zivid::Calibration::calibrateMultiCamera)

--- a/test/calibration/test_calibration_board_detection.py
+++ b/test/calibration/test_calibration_board_detection.py
@@ -1,0 +1,34 @@
+from zivid import calibration
+
+
+def _check_detection_result(detection_result):
+    assert detection_result.valid()
+    assert detection_result
+    assert len(detection_result.centroid() == 3)
+    assert isinstance(detection_result.pose(), calibration.Pose)
+
+
+def test_detect_calibration_board_frame(calibration_board_and_aruco_markers_frame):
+    detection_result = calibration.detect_calibration_board(
+        calibration_board_and_aruco_markers_frame
+    )
+    _check_detection_result(detection_result)
+
+
+def test_detect_calibration_board_file_camera(file_camera_calibration_board):
+    detection_result = calibration.detect_calibration_board(
+        file_camera_calibration_board
+    )
+    _check_detection_result(detection_result)
+
+
+def test_detect_calibration_board_invalid_file_camera(shared_file_camera):
+    detection_result = calibration.detect_calibration_board(shared_file_camera)
+    assert not detection_result.valid()
+    assert not detection_result
+
+
+def test_capture_calibration_board_and_then_detect(file_camera_calibration_board):
+    frame = calibration.capture_calibration_board(file_camera_calibration_board)
+    detection_result = calibration.detect_calibration_board(frame)
+    _check_detection_result(detection_result)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -47,6 +47,14 @@ def shared_file_camera_fixture(application, file_camera_file):
         yield file_cam
 
 
+@pytest.fixture(name="file_camera_calibration_board", scope="module")
+def file_camera_calibration_board_fixture(application):
+    with application.create_file_camera(
+        _testdata_dir() / "calibration_board.zfc"
+    ) as cam:
+        yield cam
+
+
 @pytest.fixture(name="default_settings", scope="module")
 def default_settings_fixture():
     return zivid.Settings(acquisitions=[zivid.Settings.Acquisition()])
@@ -81,6 +89,14 @@ def checkerboard_frames_fixture(application):
 @pytest.fixture(name="calibration_board_frame", scope="module")
 def calibration_board_frame_fixture(application):
     with zivid.Frame(_testdata_dir() / "ZVD-CB01.zdf") as frame:
+        yield frame
+
+
+@pytest.fixture(name="calibration_board_and_aruco_markers_frame", scope="module")
+def calibration_board_and_aruco_markers_frame_fixture(application):
+    with zivid.Frame(
+        _testdata_dir() / "calibration_board_and_aruco_markers.zdf"
+    ) as frame:
         yield frame
 
 

--- a/test/test_data/calibration_board.zfc
+++ b/test/test_data/calibration_board.zfc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:037c785634db01a7cad764084546f216477a3204191df7384d773d65e16bc80d
+size 31382179

--- a/test/test_data/calibration_board_and_aruco_markers.zdf
+++ b/test/test_data/calibration_board_and_aruco_markers.zdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa654e407498fc2e07535c6ed65581e97f14c171360627d03629305e0a48aba4
+size 48930654


### PR DESCRIPTION
This commit adds wrappers for new calibration board detection functions in the non-experimental `calibration` module. The following functions are added:

`detect_calibration_board` - This function can be used with either a Frame or Camera as input, and returns a DetectionResult.

`capture_calibration_board` - This function can be used to capture a frame with a Camera that later can be passed as input to the former function.