### PR TITLE
Pass wrapper name when constructing Zivid::Application

### DIFF
--- a/src/SingletonApplication.cpp
+++ b/src/SingletonApplication.cpp
@@ -1,4 +1,5 @@
 #include <Zivid/CameraInfo.h>
+#include <Zivid/Detail/ToolchainDetector.h>
 
 #include <ZividPython/SingletonApplication.h>
 
@@ -10,7 +11,13 @@ namespace ZividPython
 {
     void wrapClass(pybind11::class_<SingletonApplication> pyClass)
     {
-        pyClass.def(py::init())
+        pyClass
+            .def(py::init([] {
+                // This method constructs a Zivid::Application and identifies the wrapper as the Zivid Python wrapper.
+                // For users of the SDK: please do not use this method and construct the Zivid::Application directly instead.
+                return SingletonApplication{ Zivid::Detail::createApplicationForWrapper(
+                    Zivid::Detail::EnvironmentInfo::Wrapper::python) };
+            }))
             .def("cameras", &SingletonApplication::cameras)
             .def("connect_camera", [](SingletonApplication &application) { return application.connectCamera(); })
             .def(

--- a/src/include/ZividPython/Releasable.h
+++ b/src/include/ZividPython/Releasable.h
@@ -1,9 +1,14 @@
 #pragma once
 
+#include <ZividPython/Traits.h>
+
+#include <pybind11/pybind11.h>
+
+#include <cstddef>
 #include <memory>
 #include <optional>
-#include <pybind11/pybind11.h>
 #include <stdexcept>
+#include <type_traits>
 
 #define WITH_GIL_UNLOCKED(...)                                                                                         \
     [&, this] {                                                                                                        \
@@ -129,12 +134,13 @@ namespace ZividPython
     class Singleton
     {
     public:
-        Singleton()
+        template<typename... Args, typename std::enable_if_t<(std::is_constructible_v<T, Args...>), int> = 0>
+        Singleton(Args &&...args)
         {
             // Keep the singleton alive forever to avoid races with
             // static variables that the singleton may need during destruction
             // This should be fixed a more elegant way!
-            if(!globalImpl) globalImpl = std::make_shared<T>();
+            if(!globalImpl) globalImpl = std::make_shared<T>(std::forward<Args>(args)...);
         }
 
         decltype(auto) toString() const


### PR DESCRIPTION
- Modify Singleton to accept constructor arguments for the object it manages
- Use Zivid::Detail::createApplicationForWrapper to construct the Application for the Python wrapper

Part of ZIVID-8484