### PR TITLE
Update Linux distributions test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,10 +102,10 @@ jobs:
         os:
           - ubuntu:20.04
           - ubuntu:22.04
-          - ubuntu:23.10
           - ubuntu:24.04
-          - fedora:39
+          - ubuntu:24.10
           - fedora:40
+          - fedora:41
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -171,15 +171,15 @@ Please visit [Zivid Knowledge Base][zivid-knowledge-base-url] for general inform
 
 ## Test matrix
 
-| Operating System | Python version                  |
-|:-----------------|:--------------------------------|
-| Ubuntu 24.04     | 3.12                            |
-| Ubuntu 23.10     | 3.11                            |
-| Ubuntu 22.04     | 3.10                            |
-| Ubuntu 20.04     | 3.8                             |
-| Fedora 39        | 3.12                            |
-| Fedora 40        | 3.12                            |
-| Windows 10       | 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 |
+| Operating System  | Python version                  |
+|:------------------|:--------------------------------|
+| Ubuntu 24.10      | 3.12                            |
+| Ubuntu 24.04      | 3.12                            |
+| Ubuntu 22.04      | 3.10                            |
+| Ubuntu 20.04      | 3.8                             |
+| Fedora 40         | 3.12                            |
+| Fedora 41         | 3.13                            |
+| Windows 10        | 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 |
 
 [header-image]: https://www.zivid.com/hubfs/softwarefiles/images/zivid-generic-github-header.png
 [ci-badge]: https://img.shields.io/github/actions/workflow/status/zivid/zivid-python/main.yml?branch=master


### PR DESCRIPTION
Removes Ubuntu 23.10 and Fedora 39 as they are EOL. Adds Ubuntu 24.10 and Fedora 41