### PR TITLE
Limit ninja version due to bug in the latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,6 @@
 requires = [
     "cmake>=3.24.0",
     "conan>=2,<3",
-    "ninja",
+    "ninja<=1.11.1.1",
     "scikit-build",
     ]


### PR DESCRIPTION
There is a bug in the latest ninja package in PyPI, version 1.11.1.2, that causes ninja to call itself recursively until the system runs out of memory. This commit limits ninja to the previous version, 1.11.1.1, to prevent the issue.