### PR TITLE
Unlock GIL in all releasable class methods

### DIFF
--- a/src/include/ZividPython/Releasable.h
+++ b/src/include/ZividPython/Releasable.h
@@ -25,7 +25,7 @@
 #define ZIVID_PYTHON_FORWARD_0_ARGS(functionName)                                                                      \
     decltype(auto) functionName()                                                                                      \
     {                                                                                                                  \
-        return impl().functionName();                                                                                  \
+        return WITH_GIL_UNLOCKED(impl().functionName());                                                               \
     }
 
 #define ZIVID_PYTHON_FORWARD_0_ARGS_TEMPLATE_1_ARG(functionName, returnTypeTypename)                                   \
@@ -37,7 +37,7 @@
 #define ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(returnType, functionName)                                              \
     auto functionName()                                                                                                \
     {                                                                                                                  \
-        return returnType{ impl().functionName() };                                                                    \
+        return returnType{ WITH_GIL_UNLOCKED(impl().functionName()) };                                                 \
     }
 
 #define ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_CONTAINER_RETURN(container, returnType, functionName)                         \
@@ -83,7 +83,7 @@
     template<typename Releaseable>                                                                                     \
     bool operator op(const Releaseable &other) const                                                                   \
     {                                                                                                                  \
-        return impl() op other.impl();                                                                                 \
+        return WITH_GIL_UNLOCKED(impl() op other.impl());                                                              \
     }
 
 namespace ZividPython

--- a/src/include/ZividPython/ReleasableFrame.h
+++ b/src/include/ZividPython/ReleasableFrame.h
@@ -18,6 +18,8 @@ namespace ZividPython
         ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(ReleasablePointCloud, pointCloud)
         std::optional<ReleasableFrame2D> frame2D()
         {
+            pybind11::gil_scoped_release gilLock;
+
             auto frame = impl().frame2D();
             if(!frame.has_value())
             {


### PR DESCRIPTION
In d64366eb, the wrapper macros in Releasable.h were updated to unlock the GIL when calling into the SDK. However, it seems a couple of macros were missed in this commit. This meant that functions like `Frame::point_cloud` and `Camera::state` could not run in parallel.

This commit adds the GIL unlocking to the wrapper macros that were missed and also add the GIL unlock to one function that does not use wrapper macros.