### PR TITLE
Misc 2025 04 03 add copy and clone

### DIFF
--- a/modules/zivid/frame.py
+++ b/modules/zivid/frame.py
@@ -153,3 +153,6 @@ class Frame:
 
     def __del__(self):
         self.release()
+
+    def __copy__(self):
+        return Frame(self.__impl.__copy__())

--- a/modules/zivid/frame.py
+++ b/modules/zivid/frame.py
@@ -145,6 +145,23 @@ class Frame:
         else:
             impl.release()
 
+    def clone(self):
+        """Get a clone of the frame.
+
+        The clone will include a copy of all the point cloud data on the compute device memory. This means that the
+        returned frame will not be affected by subsequent modifications on the original frame or point cloud.
+
+        This function incurs a performance cost due to the copying of the compute device memory. When performance is
+        important we recommend to avoid using this method, and instead modify the existing frame or point cloud.
+
+        This method is equivalent to calling `copy.deepcopy` on the frame. You can obtain a shallow copy that does
+        not copy the underlying data by using `copy.copy` on the frame instead.
+
+        Returns:
+            A Frame instance
+        """
+        return Frame(self.__impl.clone())
+
     def __enter__(self):
         return self
 
@@ -156,3 +173,6 @@ class Frame:
 
     def __copy__(self):
         return Frame(self.__impl.__copy__())
+
+    def __deepcopy__(self, memodict):
+        return Frame(self.__impl.__deepcopy__(memodict))

--- a/modules/zivid/frame_2d.py
+++ b/modules/zivid/frame_2d.py
@@ -114,3 +114,6 @@ class Frame2D:
 
     def __del__(self):
         self.release()
+
+    def __copy__(self):
+        return Frame2D(self.__impl.__copy__())

--- a/modules/zivid/frame_2d.py
+++ b/modules/zivid/frame_2d.py
@@ -106,6 +106,22 @@ class Frame2D:
         else:
             impl.release()
 
+    def clone(self):
+        """Get a clone of the frame.
+
+        The clone will include a copy of all the frame data.
+
+        This function incurs a performance cost due to the copying of the data. When performance is important we
+        recommend to avoid using this method, and instead modify the existing frame.
+
+        This method is equivalent to calling `copy.deepcopy` on the frame. You can obtain a shallow copy that does
+        not copy the underlying data by using `copy.copy` on the frame instead.
+
+        Returns:
+            A Frame2D instance
+        """
+        return Frame2D(self.__impl.clone())
+
     def __enter__(self):
         return self
 
@@ -117,3 +133,6 @@ class Frame2D:
 
     def __copy__(self):
         return Frame2D(self.__impl.__copy__())
+
+    def __deepcopy__(self, memodict):
+        return Frame2D(self.__impl.__deepcopy__(memodict))

--- a/modules/zivid/image.py
+++ b/modules/zivid/image.py
@@ -124,3 +124,6 @@ class Image:
 
     def __del__(self):
         self.release()
+
+    def __copy__(self):
+        return Image(self.__impl.__copy__())

--- a/modules/zivid/point_cloud.py
+++ b/modules/zivid/point_cloud.py
@@ -253,3 +253,6 @@ class PointCloud:
 
     def __del__(self):
         self.release()
+
+    def __copy__(self):
+        return PointCloud(self.__impl.__copy__())

--- a/modules/zivid/point_cloud.py
+++ b/modules/zivid/point_cloud.py
@@ -143,6 +143,24 @@ class PointCloud:
             )
         )
 
+    def clone(self):
+        """Get a clone of the point cloud.
+
+        The clone will include a copy of all the point cloud data on the compute device memory. This means that the
+        returned point cloud will not be affected by subsequent modifications (such as transform or downsample) on the
+        original point cloud.
+
+        This function incurs a performance cost due to the copying of the compute device memory. When performance is
+        important we recommend to avoid using this method, and instead modify the existing point cloud.
+
+        This method is equivalent to calling `copy.deepcopy` on the point cloud. You can obtain a shallow copy that does
+        not copy the underlying data by using `copy.copy` on the point cloud instead.
+
+        Returns:
+            A new PointCloud instance
+        """
+        return PointCloud(self.__impl.clone())
+
     def transform(self, matrix):
         """Transform the point cloud in-place by a 4x4 transformation matrix.
 
@@ -256,3 +274,6 @@ class PointCloud:
 
     def __copy__(self):
         return PointCloud(self.__impl.__copy__())
+
+    def __deepcopy__(self, memodict):
+        return PointCloud(self.__impl.__deepcopy__(memodict))

--- a/src/ReleasableFrame.cpp
+++ b/src/ReleasableFrame.cpp
@@ -17,6 +17,7 @@ namespace ZividPython
             .def_property_readonly("info", &ReleasableFrame::info)
             .def_property_readonly("camera_info", &ReleasableFrame::cameraInfo)
             .def("point_cloud", &ReleasableFrame::pointCloud)
-            .def("frame_2d", &ReleasableFrame::frame2D);
+            .def("frame_2d", &ReleasableFrame::frame2D)
+            .def("clone", &ReleasableFrame::clone);
     }
 } // namespace ZividPython

--- a/src/ReleasableFrame2D.cpp
+++ b/src/ReleasableFrame2D.cpp
@@ -14,6 +14,7 @@ namespace ZividPython
             .def_property_readonly("camera_info", &ReleasableFrame2D::cameraInfo)
             .def("image_rgba", &ReleasableFrame2D::imageRGBA)
             .def("image_bgra", &ReleasableFrame2D::imageBGRA)
-            .def("image_srgb", &ReleasableFrame2D::imageSRGB);
+            .def("image_srgb", &ReleasableFrame2D::imageSRGB)
+            .def("clone", &ReleasableFrame2D::clone);
     }
 } // namespace ZividPython

--- a/src/ReleasablePointCloud.cpp
+++ b/src/ReleasablePointCloud.cpp
@@ -28,7 +28,8 @@ namespace ZividPython
                  })
             .def("copy_image_rgba", &ReleasablePointCloud::copyImageRGBA)
             .def("copy_image_bgra", &ReleasablePointCloud::copyImageBGRA)
-            .def("copy_image_srgb", &ReleasablePointCloud::copyImageSRGB);
+            .def("copy_image_srgb", &ReleasablePointCloud::copyImageSRGB)
+            .def("clone", &ReleasablePointCloud::clone);
 
         py::enum_<Zivid::PointCloud::Downsampling>{ pyClass, "Downsampling" }
             .value("by2x2", Zivid::PointCloud::Downsampling::by2x2)

--- a/src/include/ZividPython/Releasable.h
+++ b/src/include/ZividPython/Releasable.h
@@ -86,13 +86,18 @@
         return WITH_GIL_UNLOCKED(impl() op other.impl());                                                              \
     }
 
+#define ZIVID_PYTHON_ADD_COPY_CONSTRUCTOR(className)                                                                    \
+    className(const className &other)                                                                                   \
+        : Releasable{ other }                                                                                          \
+    {}
+
 namespace ZividPython
 {
     template<typename T>
     class Releasable
     {
     public:
-        template<typename... Args>
+        template<typename... Args, std::enable_if_t<std::is_constructible_v<T, Args...>, int> = 0>
         explicit Releasable(Args &&...args)
             : m_impl{ std::make_optional<T>(std::forward<Args>(args)...) }
         {}
@@ -134,7 +139,7 @@ namespace ZividPython
     class Singleton
     {
     public:
-        template<typename... Args, typename std::enable_if_t<(std::is_constructible_v<T, Args...>), int> = 0>
+        template<typename... Args, std::enable_if_t<(std::is_constructible_v<T, Args...>), int> = 0>
         Singleton(Args &&...args)
         {
             // Keep the singleton alive forever to avoid races with

--- a/src/include/ZividPython/Releasable.h
+++ b/src/include/ZividPython/Releasable.h
@@ -16,22 +16,10 @@
         return __VA_ARGS__;                                                                                            \
     }()
 
-#define ZIVID_PYTHON_FORWARD_0_ARGS_TEMPLATE_1_ARG_WRAP_RETURN(returnType, functionName, returnTypeTypename)           \
-    auto functionName()                                                                                                \
-    {                                                                                                                  \
-        return returnType{ WITH_GIL_UNLOCKED(impl().functionName<returnTypeTypename>()) };                             \
-    }
-
 #define ZIVID_PYTHON_FORWARD_0_ARGS(functionName)                                                                      \
     decltype(auto) functionName()                                                                                      \
     {                                                                                                                  \
         return WITH_GIL_UNLOCKED(impl().functionName());                                                               \
-    }
-
-#define ZIVID_PYTHON_FORWARD_0_ARGS_TEMPLATE_1_ARG(functionName, returnTypeTypename)                                   \
-    decltype(auto) functionName()                                                                                      \
-    {                                                                                                                  \
-        return WITH_GIL_UNLOCKED(impl().functionName<returnTypeTypename>());                                           \
     }
 
 #define ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(returnType, functionName)                                              \

--- a/src/include/ZividPython/Releasable.h
+++ b/src/include/ZividPython/Releasable.h
@@ -16,20 +16,20 @@
         return __VA_ARGS__;                                                                                            \
     }()
 
-#define ZIVID_PYTHON_FORWARD_0_ARGS(functionName)                                                                      \
-    decltype(auto) functionName()                                                                                      \
+#define ZIVID_PYTHON_FORWARD_0_ARGS(functionName, ...)                                                                 \
+    decltype(auto) functionName() __VA_ARGS__                                                                          \
     {                                                                                                                  \
         return WITH_GIL_UNLOCKED(impl().functionName());                                                               \
     }
 
-#define ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(returnType, functionName)                                              \
-    auto functionName()                                                                                                \
+#define ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(returnType, functionName, ...)                                         \
+    auto functionName() __VA_ARGS__                                                                                    \
     {                                                                                                                  \
         return returnType{ WITH_GIL_UNLOCKED(impl().functionName()) };                                                 \
     }
 
-#define ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_CONTAINER_RETURN(container, returnType, functionName)                         \
-    auto functionName()                                                                                                \
+#define ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_CONTAINER_RETURN(container, returnType, functionName, ...)                    \
+    auto functionName() __VA_ARGS__                                                                                    \
     {                                                                                                                  \
         auto nativeContainer = WITH_GIL_UNLOCKED(impl().functionName());                                               \
         container<returnType> returnContainer;                                                                         \
@@ -43,26 +43,26 @@
         return returnContainer;                                                                                        \
     }
 
-#define ZIVID_PYTHON_FORWARD_1_ARGS(functionName, arg1Type, arg1Name)                                                  \
-    decltype(auto) functionName(arg1Type arg1Name)                                                                     \
+#define ZIVID_PYTHON_FORWARD_1_ARGS(functionName, arg1Type, arg1Name, ...)                                             \
+    decltype(auto) functionName(arg1Type arg1Name) __VA_ARGS__                                                         \
     {                                                                                                                  \
         return WITH_GIL_UNLOCKED(impl().functionName(arg1Name));                                                       \
     }
 
-#define ZIVID_PYTHON_FORWARD_1_ARGS_WRAP_RETURN(returnType, functionName, arg1Type, arg1Name)                          \
-    auto functionName(arg1Type arg1Name)                                                                               \
+#define ZIVID_PYTHON_FORWARD_1_ARGS_WRAP_RETURN(returnType, functionName, arg1Type, arg1Name, ...)                     \
+    auto functionName(arg1Type arg1Name) __VA_ARGS__                                                                   \
     {                                                                                                                  \
         return returnType{ WITH_GIL_UNLOCKED(impl().functionName(arg1Name)) };                                         \
     }
 
-#define ZIVID_PYTHON_FORWARD_2_ARGS(functionName, arg1Type, arg1Name, arg2Type, arg2Name)                              \
-    decltype(auto) functionName(arg1Type arg1Name, arg2Type arg2Name)                                                  \
+#define ZIVID_PYTHON_FORWARD_2_ARGS(functionName, arg1Type, arg1Name, arg2Type, arg2Name, ...)                         \
+    decltype(auto) functionName(arg1Type arg1Name, arg2Type arg2Name) __VA_ARGS__                                      \
     {                                                                                                                  \
         return WITH_GIL_UNLOCKED(impl().functionName(arg1Name, arg2Name));                                             \
     }
 
-#define ZIVID_PYTHON_FORWARD_2_ARGS_WRAP_RETURN(returnType, functionName, arg1Type, arg1Name, arg2Type, arg2Name)      \
-    auto functionName(arg1Type arg1Name, arg2Type arg2Name)                                                            \
+#define ZIVID_PYTHON_FORWARD_2_ARGS_WRAP_RETURN(returnType, functionName, arg1Type, arg1Name, arg2Type, arg2Name, ...) \
+    auto functionName(arg1Type arg1Name, arg2Type arg2Name) __VA_ARGS__                                                \
     {                                                                                                                  \
         return returnType{ WITH_GIL_UNLOCKED(impl().functionName(arg1Name, arg2Name)) };                               \
     }
@@ -74,8 +74,8 @@
         return WITH_GIL_UNLOCKED(impl() op other.impl());                                                              \
     }
 
-#define ZIVID_PYTHON_ADD_COPY_CONSTRUCTOR(className)                                                                    \
-    className(const className &other)                                                                                   \
+#define ZIVID_PYTHON_ADD_COPY_CONSTRUCTOR(className)                                                                   \
+    className(const className &other)                                                                                  \
         : Releasable{ other }                                                                                          \
     {}
 

--- a/src/include/ZividPython/ReleasableFrame.h
+++ b/src/include/ZividPython/ReleasableFrame.h
@@ -31,6 +31,7 @@ namespace ZividPython
         ZIVID_PYTHON_FORWARD_0_ARGS(state)
         ZIVID_PYTHON_FORWARD_0_ARGS(info)
         ZIVID_PYTHON_FORWARD_0_ARGS(cameraInfo)
+        ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(ReleasableFrame, clone, const);
     };
 
     void wrapClass(pybind11::class_<ReleasableFrame> pyClass);

--- a/src/include/ZividPython/ReleasableFrame2D.h
+++ b/src/include/ZividPython/ReleasableFrame2D.h
@@ -14,6 +14,8 @@ namespace ZividPython
     public:
         using Releasable<Zivid::Frame2D>::Releasable;
 
+        ZIVID_PYTHON_ADD_COPY_CONSTRUCTOR(ReleasableFrame2D)
+
         ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(ReleasableImageRGBA, imageRGBA)
         ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(ReleasableImageBGRA, imageBGRA)
         ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(ReleasableImageSRGB, imageSRGB)

--- a/src/include/ZividPython/ReleasableFrame2D.h
+++ b/src/include/ZividPython/ReleasableFrame2D.h
@@ -23,6 +23,7 @@ namespace ZividPython
         ZIVID_PYTHON_FORWARD_0_ARGS(state)
         ZIVID_PYTHON_FORWARD_0_ARGS(info)
         ZIVID_PYTHON_FORWARD_0_ARGS(cameraInfo)
+        ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(ReleasableFrame2D, clone, const);
     };
 
     void wrapClass(pybind11::class_<ReleasableFrame2D> pyClass);

--- a/src/include/ZividPython/ReleasableImage.h
+++ b/src/include/ZividPython/ReleasableImage.h
@@ -11,6 +11,8 @@ namespace ZividPython
     public:
         using Releasable<Zivid::Image<Zivid::ColorRGBA>>::Releasable;
 
+        ZIVID_PYTHON_ADD_COPY_CONSTRUCTOR(ReleasableImageRGBA)
+
         ZIVID_PYTHON_FORWARD_1_ARGS(save, const std::string &, fileName)
         ZIVID_PYTHON_FORWARD_0_ARGS(width)
         ZIVID_PYTHON_FORWARD_0_ARGS(height)
@@ -21,6 +23,8 @@ namespace ZividPython
     public:
         using Releasable<Zivid::Image<Zivid::ColorBGRA>>::Releasable;
 
+        ZIVID_PYTHON_ADD_COPY_CONSTRUCTOR(ReleasableImageBGRA)
+
         ZIVID_PYTHON_FORWARD_1_ARGS(save, const std::string &, fileName)
         ZIVID_PYTHON_FORWARD_0_ARGS(width)
         ZIVID_PYTHON_FORWARD_0_ARGS(height)
@@ -30,6 +34,8 @@ namespace ZividPython
     {
     public:
         using Releasable<Zivid::Image<Zivid::ColorSRGB>>::Releasable;
+
+        ZIVID_PYTHON_ADD_COPY_CONSTRUCTOR(ReleasableImageSRGB)
 
         ZIVID_PYTHON_FORWARD_1_ARGS(save, const std::string &, fileName)
         ZIVID_PYTHON_FORWARD_0_ARGS(width)

--- a/src/include/ZividPython/ReleasablePointCloud.h
+++ b/src/include/ZividPython/ReleasablePointCloud.h
@@ -25,6 +25,7 @@ namespace ZividPython
         ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(ReleasableImageRGBA, copyImageRGBA)
         ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(ReleasableImageBGRA, copyImageBGRA)
         ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(ReleasableImageSRGB, copyImageSRGB)
+        ZIVID_PYTHON_FORWARD_0_ARGS_WRAP_RETURN(ReleasablePointCloud, clone, const);
     };
 
     void wrapClass(pybind11::class_<ReleasablePointCloud> pyClass);

--- a/src/include/ZividPython/ReleasablePointCloud.h
+++ b/src/include/ZividPython/ReleasablePointCloud.h
@@ -12,6 +12,8 @@ namespace ZividPython
     public:
         using Releasable<Zivid::PointCloud>::Releasable;
 
+        ZIVID_PYTHON_ADD_COPY_CONSTRUCTOR(ReleasablePointCloud)
+
         ZIVID_PYTHON_FORWARD_0_ARGS(width)
         ZIVID_PYTHON_FORWARD_0_ARGS(height)
         ZIVID_PYTHON_FORWARD_1_ARGS(transform, const Zivid::Matrix4x4 &, matrix)

--- a/src/include/ZividPython/Wrappers.h
+++ b/src/include/ZividPython/Wrappers.h
@@ -22,6 +22,9 @@ namespace ZividPython
         template<typename T>
         using bool_t = decltype(static_cast<bool>(std::declval<T>()));
 
+        template<typename T>
+        using clone_t = decltype(std::declval<T>().clone());
+
         /// Inserts underscore on positive case flank and before negative case flank:
         /// ZividSDKVersion -> zivid_sdk_version
         std::string toSnakeCase(std::string_view upperCamelCase)
@@ -81,6 +84,12 @@ namespace ZividPython
         if constexpr(std::is_copy_constructible_v<Source>)
         {
             pyClass.def("__copy__", [](const Source &self) { return Source{ self }; });
+        }
+
+        // Add __deepcopy__ if Source has a clone method
+        if constexpr(is_detected<clone_t, Source>::value)
+        {
+            pyClass.def("__deepcopy__", [](const Source &self, const pybind11::dict &) { return self.clone(); });
         }
 
         if constexpr(WrapType::releasable == wrapType)

--- a/src/include/ZividPython/Wrappers.h
+++ b/src/include/ZividPython/Wrappers.h
@@ -78,6 +78,11 @@ namespace ZividPython
             pyClass.def("__bool__", &Source::operator bool);
         }
 
+        if constexpr(std::is_copy_constructible_v<Source>)
+        {
+            pyClass.def("__copy__", [](const Source &self) { return Source{ self }; });
+        }
+
         if constexpr(WrapType::releasable == wrapType)
         {
             pyClass.def("release", &Source::release).def("assert_not_released", &Source::assertNotReleased);

--- a/test/assertions.py
+++ b/test/assertions.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+
+def _assert_xyzrgba_equal(a, b):
+    # Also works for xyzbgra
+
+    for key in "xyzrgba":
+        np.testing.assert_array_equal(a[key], b[key])
+
+
+def assert_point_clouds_equal(a, b):
+    assert b.height == a.height
+    assert b.width == a.width
+
+    np.testing.assert_array_equal(a.copy_data("xyz"), b.copy_data("xyz"))
+    np.testing.assert_array_equal(a.copy_data("xyzw"), b.copy_data("xyzw"))
+    _assert_xyzrgba_equal(
+        a.copy_data("xyzrgba"),
+        b.copy_data("xyzrgba"),
+    )
+    _assert_xyzrgba_equal(
+        a.copy_data("xyzbgra"),
+        b.copy_data("xyzbgra"),
+    )
+    np.testing.assert_array_equal(a.copy_data("rgba"), b.copy_data("rgba"))
+    np.testing.assert_array_equal(a.copy_data("bgra"), b.copy_data("bgra"))
+    np.testing.assert_array_equal(a.copy_data("srgb"), b.copy_data("srgb"))
+    np.testing.assert_array_equal(a.copy_data("normals"), b.copy_data("normals"))
+    np.testing.assert_array_equal(a.copy_data("z"), b.copy_data("z"))
+    np.testing.assert_array_equal(a.copy_data("snr"), b.copy_data("snr"))
+
+
+def assert_point_clouds_not_equal(a, b):
+    try:
+        assert_point_clouds_equal(a, b)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("Point clouds are equal")

--- a/test/test_frame.py
+++ b/test/test_frame.py
@@ -113,13 +113,57 @@ def test_release(frame):
         frame.point_cloud()
 
 
-def test_copy(frame):
+def test_copy(frame, transform):
+    import zivid
     import copy
+    from assertions import assert_point_clouds_equal
 
     frame_copy = copy.copy(frame)
     assert frame_copy
     assert frame_copy is not frame
     assert isinstance(frame_copy, type(frame))
 
+    assert_point_clouds_equal(frame.point_cloud(), frame_copy.point_cloud())
+    # shallow copy, point cloud transform should affect both
+    frame.point_cloud().transform(transform)
+    assert_point_clouds_equal(frame.point_cloud(), frame_copy.point_cloud())
+
     frame.release()
     assert isinstance(frame_copy.point_cloud(), zivid.PointCloud)
+
+
+def test_deepcopy(frame, transform):
+    import zivid
+    import copy
+    from assertions import assert_point_clouds_equal, assert_point_clouds_not_equal
+
+    frame_deepcopy = copy.deepcopy(frame)
+    assert frame_deepcopy
+    assert frame_deepcopy is not frame
+    assert isinstance(frame_deepcopy, type(frame))
+
+    assert_point_clouds_equal(frame.point_cloud(), frame_deepcopy.point_cloud())
+    # deep copy, point cloud transform should not affect both
+    frame.point_cloud().transform(transform)
+    assert_point_clouds_not_equal(frame.point_cloud(), frame_deepcopy.point_cloud())
+
+    frame.release()
+    assert isinstance(frame_deepcopy.point_cloud(), zivid.PointCloud)
+
+
+def test_clone(frame, transform):
+    import zivid
+    from assertions import assert_point_clouds_equal, assert_point_clouds_not_equal
+
+    frame_clone = frame.clone()
+    assert frame_clone
+    assert frame_clone is not frame
+    assert isinstance(frame_clone, type(frame))
+
+    assert_point_clouds_equal(frame.point_cloud(), frame_clone.point_cloud())
+    # clone, point cloud transform should not affect both
+    frame.point_cloud().transform(transform)
+    assert_point_clouds_not_equal(frame.point_cloud(), frame_clone.point_cloud())
+
+    frame.release()
+    assert isinstance(frame_clone.point_cloud(), zivid.PointCloud)

--- a/test/test_frame.py
+++ b/test/test_frame.py
@@ -111,3 +111,15 @@ def test_release(frame):
     frame.release()
     with pytest.raises(RuntimeError):
         frame.point_cloud()
+
+
+def test_copy(frame):
+    import copy
+
+    frame_copy = copy.copy(frame)
+    assert frame_copy
+    assert frame_copy is not frame
+    assert isinstance(frame_copy, type(frame))
+
+    frame.release()
+    assert isinstance(frame_copy.point_cloud(), zivid.PointCloud)

--- a/test/test_frame_2d.py
+++ b/test/test_frame_2d.py
@@ -88,3 +88,13 @@ def test_context_manager(shared_file_camera):
         frame_2d.image_bgra()
     with pytest.raises(RuntimeError):
         frame_2d.image_bgra()
+
+
+def test_copy(frame_2d):
+    import copy
+    import zivid
+
+    with copy.copy(frame_2d) as frame_2d_copy:
+        assert frame_2d_copy
+        assert frame_2d_copy is not frame_2d
+        assert isinstance(frame_2d_copy, zivid.Frame2D)

--- a/test/test_frame_2d.py
+++ b/test/test_frame_2d.py
@@ -98,3 +98,31 @@ def test_copy(frame_2d):
         assert frame_2d_copy
         assert frame_2d_copy is not frame_2d
         assert isinstance(frame_2d_copy, zivid.Frame2D)
+        np.testing.assert_array_equal(
+            frame_2d.image_rgba().copy_data(), frame_2d_copy.image_rgba().copy_data()
+        )
+
+
+def test_deepcopy(frame_2d):
+    import copy
+    import zivid
+
+    with copy.deepcopy(frame_2d) as frame_2d_copy:
+        assert frame_2d_copy
+        assert frame_2d_copy is not frame_2d
+        assert isinstance(frame_2d_copy, zivid.Frame2D)
+        np.testing.assert_array_equal(
+            frame_2d.image_rgba().copy_data(), frame_2d_copy.image_rgba().copy_data()
+        )
+
+
+def test_clone(frame_2d):
+    import zivid
+
+    frame_2d_clone = frame_2d.clone()
+    assert frame_2d_clone
+    assert frame_2d_clone is not frame_2d
+    assert isinstance(frame_2d_clone, zivid.Frame2D)
+    np.testing.assert_array_equal(
+        frame_2d.image_rgba().copy_data(), frame_2d_clone.image_rgba().copy_data()
+    )

--- a/test/test_image_2d_bgra.py
+++ b/test/test_image_2d_bgra.py
@@ -63,3 +63,16 @@ def test_load(frame_2d: zivid.Frame2D):
 
             with pytest.raises(ValueError):
                 zivid.Image.load(image_file, "bgr")
+
+
+def test_copy(frame_2d: zivid.Frame2D):
+    import copy
+
+    with frame_2d.image_bgra() as image_2d:
+        with copy.copy(image_2d) as copied_image:
+            assert copied_image is not None
+            assert isinstance(copied_image, zivid.Image)
+            assert copied_image is not image_2d
+            np.testing.assert_array_equal(
+                image_2d.copy_data(), copied_image.copy_data()
+            )

--- a/test/test_image_2d_rgba.py
+++ b/test/test_image_2d_rgba.py
@@ -63,3 +63,16 @@ def test_load(frame_2d: zivid.Frame2D):
 
             with pytest.raises(ValueError):
                 zivid.Image.load(image_file, "rgb")
+
+
+def test_copy(frame_2d: zivid.Frame2D):
+    import copy
+
+    with frame_2d.image_rgba() as image_2d:
+        with copy.copy(image_2d) as copied_image:
+            assert copied_image is not None
+            assert isinstance(copied_image, zivid.Image)
+            assert copied_image is not image_2d
+            np.testing.assert_array_equal(
+                image_2d.copy_data(), copied_image.copy_data()
+            )

--- a/test/test_image_2d_srgb.py
+++ b/test/test_image_2d_srgb.py
@@ -63,3 +63,16 @@ def test_load(frame_2d: zivid.Frame2D):
 
             with pytest.raises(ValueError):
                 zivid.Image.load(image_file, "srg")
+
+
+def test_copy(frame_2d: zivid.Frame2D):
+    import copy
+
+    with frame_2d.image_srgb() as image_2d:
+        with copy.copy(image_2d) as copied_image:
+            assert copied_image is not None
+            assert isinstance(copied_image, zivid.Image)
+            assert copied_image is not image_2d
+            np.testing.assert_array_equal(
+                image_2d.copy_data(), copied_image.copy_data()
+            )

--- a/test/test_point_cloud.py
+++ b/test/test_point_cloud.py
@@ -361,13 +361,48 @@ def test_illegal_init(application):
         zivid.PointCloud(123)
 
 
-def test_copy_point_cloud(frame):
+def test_copy_point_cloud(frame, transform):
     import copy
     import zivid
+    from assertions import assert_point_clouds_equal
 
     with frame.point_cloud() as point_cloud:
         with copy.copy(point_cloud) as point_cloud_copy:
             assert isinstance(point_cloud_copy, zivid.PointCloud)
             assert point_cloud_copy is not point_cloud
-            assert point_cloud_copy.height == point_cloud.height
-            assert point_cloud_copy.width == point_cloud.width
+            assert_point_clouds_equal(point_cloud, point_cloud_copy)
+
+            point_cloud.transform(transform)
+            # shallow copy, transform should have affected both copies
+            assert_point_clouds_equal(point_cloud, point_cloud_copy)
+
+
+def test_deepcopy_point_cloud(frame, transform):
+    import copy
+    import zivid
+    from assertions import assert_point_clouds_equal, assert_point_clouds_not_equal
+
+    with frame.point_cloud() as point_cloud:
+        with copy.deepcopy(point_cloud) as point_cloud_copy:
+            assert isinstance(point_cloud_copy, zivid.PointCloud)
+            assert point_cloud_copy is not point_cloud
+            assert_point_clouds_equal(point_cloud, point_cloud_copy)
+
+            point_cloud.transform(transform)
+            # deep copy, transform should not have affected the copy
+            assert_point_clouds_not_equal(point_cloud, point_cloud_copy)
+
+
+def test_clone_point_cloud(frame, transform):
+    import zivid
+    from assertions import assert_point_clouds_equal, assert_point_clouds_not_equal
+
+    with frame.point_cloud() as point_cloud:
+        with point_cloud.clone() as point_cloud_clone:
+            assert isinstance(point_cloud_clone, zivid.PointCloud)
+            assert point_cloud_clone is not point_cloud
+            assert_point_clouds_equal(point_cloud, point_cloud_clone)
+
+            point_cloud.transform(transform)
+            # clone, transform should not have affected the clone
+            assert_point_clouds_not_equal(point_cloud, point_cloud_clone)

--- a/test/test_point_cloud.py
+++ b/test/test_point_cloud.py
@@ -359,3 +359,15 @@ def test_illegal_init(application):
 
     with pytest.raises(TypeError):
         zivid.PointCloud(123)
+
+
+def test_copy_point_cloud(frame):
+    import copy
+    import zivid
+
+    with frame.point_cloud() as point_cloud:
+        with copy.copy(point_cloud) as point_cloud_copy:
+            assert isinstance(point_cloud_copy, zivid.PointCloud)
+            assert point_cloud_copy is not point_cloud
+            assert point_cloud_copy.height == point_cloud.height
+            assert point_cloud_copy.width == point_cloud.width


### PR DESCRIPTION
This PR implements support for the [copy](https://docs.python.org/3/library/copy.html) module in `Frame`, `Frame2D` and `PointCloud` classes. Both shallow `copy` and `deepcopy` are supported.

Additionally, the `clone` method is added to be similar to the C++ API. This is also a deep copy.