### PR TITLE
FW: Release GIL before calling native updateFirmware

### DIFF
--- a/samples/sample_update_firmware.py
+++ b/samples/sample_update_firmware.py
@@ -1,0 +1,33 @@
+"""Update firmware on the Zivid camera."""
+
+import zivid
+
+
+def _main() -> None:
+    app = zivid.Application()
+
+    cameras = app.cameras()
+    if len(cameras) == 0:
+        raise TimeoutError("No camera found.")
+
+    print(f"Found {len(cameras)} camera(s)")
+    for camera in cameras:
+        if not zivid.firmware.is_up_to_date(camera):
+            print("Firmware update required")
+            print(
+                f"Updating firmware on camera {camera.info.serial_number}, model name: {camera.info.model_name}, firmware version: {camera.info.firmware_version}"
+            )
+            zivid.firmware.update(
+                camera,
+                progress_callback=lambda progress, description: print(
+                    f'{progress}% : {description}{("", "...")[progress < 100]}'
+                ),
+            )
+        else:
+            print(
+                f"Skipping update of camera {camera.info.serial_number}, model name: {camera.info.model_name}, firmware version: {camera.info.firmware_version}"
+            )
+
+
+if __name__ == "__main__":
+    _main()

--- a/src/Firmware.cpp
+++ b/src/Firmware.cpp
@@ -13,6 +13,9 @@ namespace ZividPython::Firmware
         dest.def(
                 "update",
                 [](ReleasableCamera &camera, const Zivid::Firmware::ProgressCallback &callback) {
+                    // Release GIL to allow the callback function to run python code that may
+                    // require GIL, e.g., `print` function.
+                    pybind11::gil_scoped_release releaseGil;
                     Zivid::Firmware::update(camera.impl(), callback);
                 },
                 py::arg("camera"),


### PR DESCRIPTION
By default, `pybind11` will acquire python's global interpreter lock GIL before calling native code. Now `firmware.update` function accepts a user callback to log current firmware update status. It's quite common to use python's `print` function in this callback. Python's `print` function will also try to acquire GIL while we are holding the lock (default pybind11 behavior). This leads to a deadlock.

Since we do not call any python code in `Zivid::Firmware::update` function, there is no need to hold the GIL. Hence release the GIL before calling `Zivid::Firmware::update`. Then the user callback is free to acquire GIL and there is no deadlock.

Fixes ZIVID-10304